### PR TITLE
feat(bot): add repeat debug command

### DIFF
--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -43,14 +43,14 @@ client.on(Events.MessageCreate, async (message) => {
   const [command, ...args] = withoutPrefix.split(/\s+/);
 
   if (command?.toLowerCase() === 'repeat') {
-    const text = args.join(' ');
+    const repeatText = args.join(' ');
 
-    if (!text) {
+    if (!repeatText) {
       await message.reply('Tu dois fournir un texte.');
       return;
     }
 
-    await message.reply(text);
+    await message.reply(repeatText);
   }
 });
 

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -25,14 +25,32 @@ client.once(Events.ClientReady, (c) => {
   console.log(`Bot connecté : ${c.user.tag}`);
 });
 
-// TODO: supprimer, c'est pour test
+// TODO: supprimer avant la PROD (j'ai fussioner les 2 tests)
 client.on(Events.MessageCreate, async (message) => {
   if (message.author.bot) return;
+
   const content = message.content.trim();
   if (!content.startsWith(prefix)) return;
-  const command = content.slice(prefix.length).trim().toLowerCase();
-  if (command === 'one piece') {
+
+  const withoutPrefix = content.slice(prefix.length).trim();
+  const normalized = withoutPrefix.toLowerCase();
+
+  if (normalized === 'one piece') {
     await message.reply('hello world');
+    return;
+  }
+
+  const [command, ...args] = withoutPrefix.split(/\s+/);
+
+  if (command?.toLowerCase() === 'repeat') {
+    const text = args.join(' ');
+
+    if (!text) {
+      await message.reply('Tu dois fournir un texte.');
+      return;
+    }
+
+    await message.reply(text);
   }
 });
 


### PR DESCRIPTION
Contexte
Ajout d’une commande debug pour vérifier que le bot reçoit et traite correctement les messages.

Implémentation
- Ajout de la commande `<prefix>repeat <texte>`
- Le bot renvoie le texte fourni
- Fusion avec le handler existant

tests
- <prefix> repeat bonjour → bonjour
- <prefix> repeat one piece → one piece
- <prefix> one piece → hello world