### PR TITLE
add documentation

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -14,13 +14,14 @@ On ouvre un domaine (dossier + doc) uniquement au moment où on commence à code
 
 | Domaine       | Responsabilité                                                             |
 | ------------- | -------------------------------------------------------------------------- |
-| `player`      | Compte joueur, progression globale                                         |
+| `player`      | Compte joueur, progression globale, bounty, karma                          |
 | `ship`        | Navire du joueur : stats, modules, capacité de la réserve et de l'équipage |
 | `character`   | Personnages possédés (réserve) et leur arbre d'évolution                   |
 | `crew`        | Personnages actifs embarqués sur le navire                                 |
 | `event`       | Événements déclenchés lors du `/récap` (AFK)                               |
 | `devil_fruit` | Fruits du Démon : bonus de stats et types additionnels pour un personnage  |
 | `economy`     | Berry, shops, marchands                                                    |
+| `resource`    | Matériaux de craft, artefacts de main story, FDD non consommés             |
 
 D'autres domaines viendront s'ajouter quand le besoin apparaîtra (combat, world…). On ne les crée pas en amont.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ On ouvre un domaine (dossier + doc) uniquement au moment où on commence à code
 | `player`      | Compte joueur, progression globale, bounty, karma                          |
 | `ship`        | Navire du joueur : stats, modules, capacité de la réserve et de l'équipage |
 | `character`   | Personnages possédés (réserve) et leur arbre d'évolution                   |
-| `crew`        | Personnages actifs embarqués sur le navire                                 |
+| `crew`        | Personnages actifs embarqués sur le navire, moral d'équipage               |
 | `event`       | Événements déclenchés lors du `/récap` (AFK)                               |
 | `devil_fruit` | Fruits du Démon : bonus de stats et types additionnels pour un personnage  |
 | `economy`     | Berry, shops, marchands                                                    |

--- a/docs/domains/crew.md
+++ b/docs/domains/crew.md
@@ -21,3 +21,18 @@ L'équipage détermine :
 ## Composer son équipage
 
 Le joueur arbitre entre ses personnages en réserve pour choisir qui embarquer. Ce choix est stratégique : un personnage laissé en réserve ne participe à rien.
+
+## Moral
+
+L'équipage porte un **moral** collectif — un attribut au niveau du crew, pas par personnage.
+
+**Effets** :
+
+- débloque ou verrouille certains events (un équipage au moral bas ne tente pas de s'aventurer sur une île)
+- **prévient la mutinerie** — en dessous d'un seuil, un personnage peut quitter l'équipage,
+- facilite la **persuasion** de personnages pour qu'ils rejoignent l'équipage. (Shanks veut rejoindre un équipage qui sait s'amuser)
+
+**Sources de variation** :
+
+- objets consommables (ex: alcool, festin — voir `resource` et `economy`),
+- events (victoires éclatantes → +moral ; défaites, trahisons → −moral),

--- a/docs/domains/economy.md
+++ b/docs/domains/economy.md
@@ -11,7 +11,7 @@ Le Berry est la monnaie unique. Le joueur en gagne :
 - via les events (récompenses, butin, coffres…),
 - via les combats,
 - via les quêtes,
-- en **revendant des items** à un marchand (Fruits du Démon, ressources, esclaves…).
+- en **revendant des items** à un marchand (Fruits du Démon non consommés, ressources de craft, esclaves…). Les artefacts de main story sont invendables (voir `resource`).
 
 Il en dépense dans les **shops**.
 
@@ -27,4 +27,4 @@ Un marchand propose un **stock limité** d'items : Fruits du Démon, améliorati
 
 ## Catalogue d'items
 
-L'economy ne possède pas les FDD (voir `devil_fruit`) ni les modules de navire (voir `ship`) — elle sert de **passerelle d'achat** vers ces domaines. Les items propres à l'economy sont les consommables, la nourriture, et tout objet générique qui ne mérite pas son propre domaine.
+L'economy ne possède pas les FDD (voir `devil_fruit`), les modules de navire (voir `ship`), ni les ressources (voir `resource`) — elle sert de **passerelle d'achat** vers ces domaines. Les items propres à l'economy sont les consommables, la nourriture, et tout objet générique qui ne mérite pas son propre domaine.

--- a/docs/domains/event.md
+++ b/docs/domains/event.md
@@ -23,8 +23,8 @@ Un event peut définir des conditions d'apparition :
 - force d'équipage ≥ X,
 - posséder tel objet,
 - avoir atteint telle étape du scénario,
-- **karma** dans une fourchette (infâme → pirates sombres type Barbe Noire ; héroïque → libérations de peuples),
-- **notoriété** (bounty) ≥ X (events d'envergure : Yonko, Mary Geoise…).
+- **karma** dans une fourchette (voir `player`),
+- **bounty** ≥ X (voir `player`) — events d'envergure : Yonko, Mary Geoise…
 
 Les `side_quest` sont particulièrement conditionnées : une rencontre avec Mihawk n'a de sens que si Zoro est embarqué.
 

--- a/docs/domains/player.md
+++ b/docs/domains/player.md
@@ -1,0 +1,28 @@
+# Domaine : player
+
+## Concept
+
+Le **joueur** est le compte Discord et sa progression globale. C'est le point d'entrée de toute action — un joueur possède un navire (voir `ship`), un équipage (voir `crew`), une réserve de personnages (voir `character`), des ressources (voir `resource`), et un solde de Berry (voir `economy`).
+
+## Bounty
+
+La prime mise sur la tête du joueur par le Gouvernement Mondial, exprimée en Berry.
+
+Gagné via :
+
+- events `main_story` marquants,
+- `side_quest` réussies,
+- victoires contre personnages notoires (Marines haut gradés, pirates rivaux…).
+
+Le bounty sert de seuil d'accès aux events d'envergure — Yonko, Mary Geoise, Seven Warlords, QG Marine…
+
+## Karma
+
+Alignement moral, d'**infâme** à **héroïque**. Qualitatif, évolue selon les choix faits pendant les events.
+
+- **Infâme** — pillage, trahison, domination. Ouvre la voie des pirates sombres type Barbe Noire
+- **Héroïque** — libération de peuples opprimés, sauvetage de civils, alliance avec les Révolutionnaires, Choix gentils
+
+Un karma donné peut être **requis** pour débloquer un event (ex: rencontre avec Dragon exige un karma héroïque) ou au contraire le **bloquer**.
+
+Bounty et karma sont **indépendants** : un joueur peut cumuler bounty énorme + karma héroïque (type Luffy) ou bounty élevé + karma infâme (type Crocodile).

--- a/docs/domains/resource.md
+++ b/docs/domains/resource.md
@@ -1,0 +1,46 @@
+# Domaine : resource
+
+## Concept
+
+Les **ressources** regroupent tous les objets que le joueur amasse et qui ne sont pas un personnage. Trois natures cohabitent dans un inventaire logique unique, avec des règles de stockage distinctes.
+
+## Les trois types
+
+### `CRAFT` — matériaux d'amélioration
+
+Consommables utilisés pour améliorer les modules du navire (voir `ship`).
+
+Exemples : bois, fer, tissu.
+
+Sources : butin d'events, quêtes, achat chez les marchands (voir `economy`).
+
+### `STORY` — artefacts de main story
+
+Objets rares liés à la progression scénario.
+
+Exemples : Poneglyphs, armes antiques, fragments de carte au trésor.
+
+- **Non consommables** — ils restent acquis indéfiniment.
+- **Invendables** — aucun marchand ne les rachète.
+- Obtenus uniquement via events `main_story` ou `side_quest` (voir `event`).
+
+### `DEVIL_FRUIT` — Fruits du Démon non consommés
+
+Tant qu'un FDD n'a pas été mangé, il vit dans l'inventaire du joueur. Deux usages exclusifs :
+
+- **Consommé** par un personnage qui n'en porte aucun — action définitive qui lie le fruit au personnage (voir `devil_fruit`).
+- **Revendu** à un marchand (voir `economy`).
+
+Les règles d'unicité, d'obtention et d'effets post-consommation sont documentées dans `devil_fruit`.
+
+## Stockage
+
+| Type          | Compte dans `storageSize` ? |
+| ------------- | --------------------------- |
+| `CRAFT`       | Oui (cale)                  |
+| `STORY`       | Non — inventaire à part     |
+| `DEVIL_FRUIT` | Non — inventaire à part     |
+
+Les matériaux `CRAFT` sont stockés dans la **cale** du navire — la capacité est fixée par l'attribut `storageSize` (voir `ship`). Quand la cale est pleine, le joueur ne peut plus ramasser de matériau tant qu'il n'a pas consommé ou crafté avec.
+
+Les `STORY` et `DEVIL_FRUIT` sont conservés à part, sans limite (l'unicité propre aux FDD plafonne déjà naturellement leur volume).

--- a/docs/domains/ship.md
+++ b/docs/domains/ship.md
@@ -1,0 +1,40 @@
+# Domaine : ship
+
+## Concept
+
+Chaque joueur possède **un navire**, et un navire appartient à **un seul joueur**. La relation est 1-1 et définitive — pas de swap Merry → Sunny, toute la progression passe par l'amélioration du navire existant.
+
+Le navire est créé automatiquement à la première opération qui en a besoin (`findOrCreateShip`). Il porte un **nom** choisi par le joueur (pas de nom par défaut).
+
+## Attributs
+
+Cinq attributs définissent ce que le joueur peut faire. Chacun est rattaché à une **partie du bateau** — c'est cette partie qu'on améliore pour monter l'attribut.
+
+| Attribut      | Partie du bateau | Effet                                                   |
+| ------------- | ---------------- | ------------------------------------------------------- |
+| `maxHp`       | Coque            | Points de vie maximum du navire                         |
+| `speed`       | Voile            | Réduit le temps entre deux events (voir `event`)        |
+| `crewSize`    | Ponts            | Nombre de personnages **actifs** (voir `crew`)          |
+| `reserveSize` | Chambres         | Nombre de personnages en **réserve** (voir `character`) |
+| `storageSize` | Cale             | Capacité d'objets stockables (voir `resource`)          |
+
+## Santé (`hp`) vs `maxHp`
+
+Deux champs distincts :
+
+- `maxHp` — plafond, monte uniquement via amélioration de la Coque.
+- `hp` — santé actuelle, bornée par `maxHp`. Baisse lorsque le navire encaisse des dégâts (monstre marin, combat naval, event hostile) et remonte via **réparation**.
+
+<!-- TODO: définir la mécanique de réparation (régénération passive ? coût en Berry / ressources ? réparation via event ?). -->
+
+## Améliorations (modules)
+
+Chaque partie du bateau peut être améliorée indépendamment par **niveaux**. Monter un niveau coûte une combinaison au choix du game design :
+
+- **ressources** (bois, fer, tissu… voir `resource`),
+- **et/ou** Berry (voir `economy`),
+- **et/ou** présence d'un personnage spécial dans l'équipage (ex: un charpentier type Franky pour améliorer la Coque),
+- **et/ou** une ability particulière,
+- **ou** déclenché par un event (ex: rencontre avec un charpentier légendaire qui améliore gratuitement un module — voir `event`).
+
+Améliorer une partie fait monter l'attribut qu'elle gouverne — améliorer la Voile augmente `speed`, améliorer la Cale augmente `storageSize`, etc.


### PR DESCRIPTION
## Résumé
- Ajoute les docs de 3 nouveaux domaines : `ship` (attributs + modules + HP/maxHp), `resource` (matériaux craft, artefacts main story, FDD non consommés) et `player` (bounty + karma, axes indépendants)
- Met à jour `architecture.md` pour lister `resource` et enrichir la ligne `player`