### PR TITLE
Creation de searchByName  pour les fruits du démons + choix de la strategie pour récupérer de la data avec !info

### DIFF
--- a/apps/bot/src/domains/devil_fruit/repository.ts
+++ b/apps/bot/src/domains/devil_fruit/repository.ts
@@ -1,0 +1,11 @@
+import { db, devilFruitTemplate, type DevilFruitTemplate } from '@one-piece/db';
+import { ilike, or, sql } from 'drizzle-orm';
+
+export async function searchByName(query: string): Promise<Array<DevilFruitTemplate>> {
+  return db
+    .select()
+    .from(devilFruitTemplate)
+    .where(or(sql`${devilFruitTemplate.name} % ${query}`, ilike(devilFruitTemplate.name, `%${query}%`)))
+    .orderBy(sql`similarity(${devilFruitTemplate.name}, ${query}) desc`)
+    .limit(25);
+}

--- a/docs/search.md
+++ b/docs/search.md
@@ -1,0 +1,60 @@
+# Recherche par nom
+
+Comment on cherche une entité quand le user tape une query (`!info luffy`, etc.).
+
+## Ce qu'on veut
+
+Que ça marche même quand c'est moche :
+
+- `luffy` → "Luffy"
+- `lufy` → "Luffy" (typo)
+- `gomu` → "Gomu Gomu no Mi" (bout du nom)
+- `GOMU` → "Gomu Gomu no Mi" (casse)
+
+## Comment
+
+Deux trucs combinés : la similarité trigram de `pg_trgm`, et un `ILIKE` classique en filet.
+
+Le trigram, ça tolère les typos. Mais ça a besoin d'au moins 3 caractères pour bosser (vu qu'un trigram, par définition, c'est 3 lettres). Donc pour les queries courtes (`mi`, `no`…), il laisse passer. D'où le `ILIKE` qui rattrape.
+
+En SQL ça donne :
+
+```sql
+SELECT *
+FROM devil_fruit_template
+WHERE name % $1 OR name ILIKE $2
+ORDER BY similarity(name, $3) DESC
+LIMIT 25;
+```
+
+Côté Drizzle :
+
+```ts
+db.select()
+  .from(table)
+  .where(or(sql`${table.name} % ${query}`, ilike(table.name, `%${query}%`)))
+  .orderBy(sql`similarity(${table.name}, ${query}) desc`)
+  .limit(25);
+```
+
+## Ce qui doit exister côté DB
+
+- L'extension `pg_trgm` (déjà activée, migration `0003`).
+- Un index GIN sur chaque colonne qu'on veut chercher :
+  ```ts
+  index('<table>_name_trgm_idx').using('gin', sql`${table.name} gin_trgm_ops`);
+  ```
+  Sans l'index, ça marche quand même mais ça scan toute la table — à éviter dès qu'il y a du volume.
+
+## Règles côté commande
+
+- Query vide ou < 2 caractères → on refuse côté handler (pas au niveau du repo). Sinon on renvoie n'importe quoi.
+- Max 25 résultats, c'est la limite des boutons/select menus Discord. Si on dépasse, le user affine.
+
+## Piège connu
+
+Si la query contient `%` ou `_`, ILIKE les prend comme wildcards. C'est pas un risque sécurité — les params sont bindés — mais la recherche peut retourner trop large. Aucun nom One Piece connu n'a ces caractères, donc YAGNI.
+
+## Injection SQL
+
+Safe. Drizzle bind tout ce qu'on interpole dans `sql\`...\``et dans`ilike(...)`. Les queries partent en prepared statement (`$1`, `$2`…), pas en string concaténée.

--- a/packages/db/src/domains/devil_fruit/devil_fruit_template/schema.ts
+++ b/packages/db/src/domains/devil_fruit/devil_fruit_template/schema.ts
@@ -22,3 +22,4 @@ export const devilFruitTemplate = pgTable(
 );
 
 export type DevilFruitTemplateInsert = typeof devilFruitTemplate.$inferInsert;
+export type DevilFruitTemplate = typeof devilFruitTemplate.$inferSelect;

--- a/packages/db/src/domains/devil_fruit/index.ts
+++ b/packages/db/src/domains/devil_fruit/index.ts
@@ -1,4 +1,4 @@
 export { devilFruitInstance } from './devil_fruit_instance/schema.js';
 export { seedDevilFruits } from './devil_fruit_template/seed.js';
-export { devilFruitTemplate, type DevilFruitTemplateInsert } from './devil_fruit_template/schema.js';
+export { devilFruitTemplate, type DevilFruitTemplate, type DevilFruitTemplateInsert } from './devil_fruit_template/schema.js';
 export { devilFruitType } from './enum.js';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,3 +1,4 @@
 export { closeDb, db, type Db } from './client.js';
 export * from './schema.js';
 export { type Player } from './domains/player/index.js';
+export { type DevilFruitTemplate } from './domains/devil_fruit/index.js';

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,2 +1,2 @@
 export { devilFruitInstance, devilFruitTemplate, devilFruitType } from './domains/devil_fruit/index.js';
-export { player, type Player } from './domains/player/index.js';
+export { player } from './domains/player/index.js';


### PR DESCRIPTION
## Résumé
- Ajoute `searchByName` côté `devil_fruit`, qui combine similarité trigram (`pg_trgm`) (je vous expliquerai c quoi) et `ILIKE` (renseignez vous c simple) comme ça on récupère toutes les entités qui ressemblent à la query du mec (gom ==> GOmu GOmu no mi,   Lufi ==> Luffy)
- J'ai documenté la stratégie dans `docs/search.md` : cas couverts, code Drizzle, prérequis DB, règles côté commande, injection SQL etc
