### PR TITLE
feat(seed): add colored logs for better readability

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,6 +14,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "chalk": "^5.6.2",
     "drizzle-orm": "^0.45.2",
     "postgres": "^3.4.9"
   },

--- a/packages/db/src/shared/seed.ts
+++ b/packages/db/src/shared/seed.ts
@@ -1,5 +1,9 @@
+import chalk from 'chalk';
 import { getTableName, type Table } from 'drizzle-orm';
 
 export function logSeed(table: Table, rows: ReadonlyArray<unknown>) {
-  console.log(`Seed ${getTableName(table)} OK (${rows.length})`);
+  const tableName = getTableName(table);
+  const count = rows.length;
+
+  console.log(`Seed ${chalk.blue(tableName)} ${chalk.green('OK')} ${chalk.yellow(`(${count})`)}`);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,9 @@ importers:
 
   packages/db:
     dependencies:
+      chalk:
+        specifier: ^5.6.2
+        version: 5.6.2
       drizzle-orm:
         specifier: ^0.45.2
         version: 0.45.2(postgres@3.4.9)
@@ -876,6 +879,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  chalk@5.6.2:
+    resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -2038,6 +2045,8 @@ snapshots:
       balanced-match: 4.0.4
 
   buffer-from@1.1.2: {}
+
+  chalk@5.6.2: {}
 
   cli-cursor@5.0.0:
     dependencies:


### PR DESCRIPTION
Contexte

Les logs de seed étaient affichés en blanc dans le terminal, ce qui rendait la lecture difficile lorsque plusieurs seeds s'exécutent à la suite.

Changements

- Ajout de couleurs dans le helper `logSeed`
- Mise en évidence :
  - du nom de la table
  - du statut (`OK`)
  - du nombre d’éléments insérés

Résultat

Les logs sont maintenant plus lisibles et permettent de distinguer rapidement les informations importantes lors de l'exécution de `pnpm db:seed`

