### PR TITLE
67 seed resource template bois fer

### DIFF
--- a/packages/db/drizzle/0009_sparkling_tony_stark.sql
+++ b/packages/db/drizzle/0009_sparkling_tony_stark.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "resource_template" ADD CONSTRAINT "resource_template_name_unique" UNIQUE("name");

--- a/packages/db/drizzle/meta/0009_snapshot.json
+++ b/packages/db/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,456 @@
+{
+  "id": "e5226cc0-5b40-480d-a304-0f26ab94f59f",
+  "prevId": "35b9be71-0e1b-4d1c-b82a-ae4c42feb458",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.devil_fruit_instance": {
+      "name": "devil_fruit_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_instance_player_template_uniq": {
+          "name": "devil_fruit_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devil_fruit_instance_template_id_devil_fruit_template_id_fk": {
+          "name": "devil_fruit_instance_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "devil_fruit_instance_player_id_player_id_fk": {
+          "name": "devil_fruit_instance_player_id_player_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_template": {
+      "name": "devil_fruit_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "devil_fruit_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::devil_fruit_type[]"
+        },
+        "hp_bonus": {
+          "name": "hp_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_bonus": {
+          "name": "combat_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_template_name_trgm_idx": {
+          "name": "devil_fruit_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devil_fruit_template_name_unique": {
+          "name": "devil_fruit_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player": {
+      "name": "player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "karma": {
+          "name": "karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounty": {
+          "name": "bounty",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_discord_id_unique": {
+          "name": "player_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_template": {
+      "name": "resource_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_template_name_unique": {
+          "name": "resource_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ship": {
+      "name": "ship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "hull_level": {
+          "name": "hull_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sail_level": {
+          "name": "sail_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "decks_level": {
+          "name": "decks_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cabins_level": {
+          "name": "cabins_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cargo_level": {
+          "name": "cargo_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ship_player_id_player_id_fk": {
+          "name": "ship_player_id_player_id_fk",
+          "tableFrom": "ship",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ship_player_id_unique": {
+          "name": "ship_player_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.devil_fruit_type": {
+      "name": "devil_fruit_type",
+      "schema": "public",
+      "values": [
+        "FEU",
+        "GLACE",
+        "MAGMA",
+        "FOUDRE",
+        "TENEBRES",
+        "LUMIERE",
+        "SABLE",
+        "GAZ",
+        "CAOUTCHOUC",
+        "POISON"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1776895565552,
       "tag": "0008_lively_quentin_quire",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1776919345390,
+      "tag": "0009_sparkling_tony_stark",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/domains/resource/index.ts
+++ b/packages/db/src/domains/resource/index.ts
@@ -1,1 +1,2 @@
-export { resourceTemplate, type ResourceTemplate } from './resource_template/schema.js';
+export { seedResources } from './resource_template/seed.js';
+export { resourceTemplate, type ResourceTemplate, type ResourceTemplateInsert } from './resource_template/schema.js';

--- a/packages/db/src/domains/resource/resource_template/data.ts
+++ b/packages/db/src/domains/resource/resource_template/data.ts
@@ -1,0 +1,12 @@
+import type { ResourceTemplateInsert } from './schema.js';
+
+export const RESOURCE_TEMPLATES_DATA: Array<ResourceTemplateInsert> = [
+  {
+    name: 'Bois',
+    imageUrl: null,
+  },
+  {
+    name: 'Fer',
+    imageUrl: null,
+  },
+];

--- a/packages/db/src/domains/resource/resource_template/schema.ts
+++ b/packages/db/src/domains/resource/resource_template/schema.ts
@@ -4,10 +4,11 @@ import { imageUrl, timestamps } from '../../../shared/helpers.js';
 
 export const resourceTemplate = pgTable('resource_template', {
   id: serial('id').primaryKey(),
-  name: varchar('name', { length: 128 }).notNull(),
+  name: varchar('name', { length: 128 }).notNull().unique(),
   ...imageUrl(),
   description: text('description'),
   ...timestamps(),
 });
 
+export type ResourceTemplateInsert = typeof resourceTemplate.$inferInsert;
 export type ResourceTemplate = typeof resourceTemplate.$inferSelect;

--- a/packages/db/src/domains/resource/resource_template/seed.ts
+++ b/packages/db/src/domains/resource/resource_template/seed.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { sql } from 'drizzle-orm';
 
 import type { Db } from '../../../client.js';
@@ -20,9 +19,4 @@ export async function seedResources(db: Db) {
     });
 
   logSeed(resourceTemplate, RESOURCE_TEMPLATES_DATA);
-  console.log(
-    `Ressources ${chalk.green('OK')} ${chalk.yellow(`(${RESOURCE_TEMPLATES_DATA.length})`)} ${chalk.blue(
-      RESOURCE_TEMPLATES_DATA.map((resource) => resource.name).join(', '),
-    )}`,
-  );
 }

--- a/packages/db/src/domains/resource/resource_template/seed.ts
+++ b/packages/db/src/domains/resource/resource_template/seed.ts
@@ -1,0 +1,28 @@
+import chalk from 'chalk';
+import { sql } from 'drizzle-orm';
+
+import type { Db } from '../../../client.js';
+import { logSeed } from '../../../shared/seed.js';
+
+import { RESOURCE_TEMPLATES_DATA } from './data.js';
+import { resourceTemplate } from './schema.js';
+
+export async function seedResources(db: Db) {
+  await db
+    .insert(resourceTemplate)
+    .values(RESOURCE_TEMPLATES_DATA)
+    .onConflictDoUpdate({
+      target: resourceTemplate.name,
+      set: {
+        imageUrl: sql`excluded.image_url`,
+        description: sql`excluded.description`,
+      },
+    });
+
+  logSeed(resourceTemplate, RESOURCE_TEMPLATES_DATA);
+  console.log(
+    `Ressources ${chalk.green('OK')} ${chalk.yellow(`(${RESOURCE_TEMPLATES_DATA.length})`)} ${chalk.blue(
+      RESOURCE_TEMPLATES_DATA.map((resource) => resource.name).join(', '),
+    )}`,
+  );
+}

--- a/packages/db/src/seed.ts
+++ b/packages/db/src/seed.ts
@@ -1,8 +1,10 @@
 import { closeDb, db } from './client.js';
 import { seedDevilFruits } from './domains/devil_fruit/index.js';
+import { seedResources } from './domains/resource/index.js';
 
 try {
   await seedDevilFruits(db);
+  await seedResources(db);
   console.log('Seed terminé');
 } catch (err) {
   console.error('Seed failed:', err);


### PR DESCRIPTION
## Résumé

Ajoute le seed des resources templates pour peupler `resource_template` avec les ressources de base.

## Changements

- Ajout de `Bois` et `Fer` dans `resource_template/data.ts`
- Ajout de `seedResources` avec insert idempotent via `onConflictDoUpdate`
- Branchement de `seedResources` dans le script principal `packages/db/src/seed.ts`
- Ajout d’une contrainte unique sur `resource_template.name`
<img width="510" height="80" alt="image" src="https://github.com/user-attachments/assets/5deccdff-260d-4c9f-9d1a-deb2b0666715" />




