### PR TITLE
feat(player): add rename command

### DIFF
--- a/apps/bot/src/domains/player/commands/index.ts
+++ b/apps/bot/src/domains/player/commands/index.ts
@@ -1,4 +1,5 @@
 import { debugCommand } from './debug.js';
 import { karmaCommand } from './karma.js';
+import { renameCommand } from './rename.js';
 
-export const playerCommands = [karmaCommand, debugCommand];
+export const playerCommands = [karmaCommand, debugCommand, renameCommand];

--- a/apps/bot/src/domains/player/commands/rename.ts
+++ b/apps/bot/src/domains/player/commands/rename.ts
@@ -1,0 +1,23 @@
+import type { Command } from '../../../shared/command.js';
+import { PlayerNameValidationError } from '../name.js';
+import { renamePlayer } from '../service.js';
+
+export const renameCommand: Command = {
+  name: 'rename',
+  async handler(message, args) {
+    try {
+      const player = await renamePlayer(message.author.id, message.author.username, args.join(' '));
+      await message.reply({
+        content: `Tu t'appelles maintenant ${player.name}.`,
+        allowedMentions: { parse: [] },
+      });
+    } catch (err) {
+      if (err instanceof PlayerNameValidationError) {
+        await message.reply(err.message);
+        return;
+      }
+
+      throw err;
+    }
+  },
+};

--- a/apps/bot/src/domains/player/commands/rename.ts
+++ b/apps/bot/src/domains/player/commands/rename.ts
@@ -1,14 +1,15 @@
 import type { Command } from '../../../shared/command.js';
 import { PlayerNameValidationError } from '../name.js';
-import { renamePlayer } from '../service.js';
+import { findOrCreatePlayer, renamePlayer } from '../service.js';
 
 export const renameCommand: Command = {
   name: 'rename',
   async handler(message, args) {
     try {
-      const player = await renamePlayer(message.author.id, message.author.username, args.join(' '));
+      const { player } = await findOrCreatePlayer(message.author.id, message.author.username);
+      const renamed = await renamePlayer(player.id, args.join(' '));
       await message.reply({
-        content: `Tu t'appelles maintenant ${player.name}.`,
+        content: `Tu t'appelles maintenant ${renamed.name}.`,
         allowedMentions: { parse: [] },
       });
     } catch (err) {

--- a/apps/bot/src/domains/player/constants.ts
+++ b/apps/bot/src/domains/player/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_PLAYER_NAME_LENGTH = 64; // Données en SQL (VARCHAR(64))

--- a/apps/bot/src/domains/player/index.ts
+++ b/apps/bot/src/domains/player/index.ts
@@ -1,3 +1,4 @@
 export { findOrCreatePlayer } from './service.js';
+export { MAX_PLAYER_NAME_LENGTH } from './constants.js';
 export { getKarmaGrade } from './karma.js';
 export { playerCommands } from './commands/index.js';

--- a/apps/bot/src/domains/player/name.ts
+++ b/apps/bot/src/domains/player/name.ts
@@ -1,0 +1,22 @@
+import { MAX_PLAYER_NAME_LENGTH } from './constants.js';
+
+const DISCORD_FORMATTING_CHARS = /[*_`~|><@/"[\]()\\]/g;
+const MULTIPLE_SPACES = /\s+/g;
+
+export class PlayerNameValidationError extends Error {}
+
+export function sanitizeName(name: string): string {
+  return name.replace(DISCORD_FORMATTING_CHARS, '').replace(MULTIPLE_SPACES, ' ').trim();
+}
+
+export function assertNameNotEmpty(name: string) {
+  if (name.length === 0) {
+    throw new PlayerNameValidationError('Tu dois donner un nom.');
+  }
+}
+
+export function assertNameWithinMaxLength(name: string) {
+  if (name.length > MAX_PLAYER_NAME_LENGTH) {
+    throw new PlayerNameValidationError(`Ton nom ne peut pas dépasser ${MAX_PLAYER_NAME_LENGTH} caractères.`);
+  }
+}

--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -10,3 +10,8 @@ export async function create(discordId: string, name: string): Promise<Player> {
   const [row] = await db.insert(player).values({ discordId, name }).returning();
   return row!;
 }
+
+export async function updateName(playerId: number, name: string): Promise<Player> {
+  const [row] = await db.update(player).set({ name }).where(eq(player.id, playerId)).returning();
+  return row!;
+}

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -12,7 +12,7 @@ export async function findOrCreatePlayer(discordId: string, name: string): Promi
   return { player: created, created: true };
 }
 
-export async function renamePlayer(discordId: string, fallbackName: string, rawName: string): Promise<Player> {
+export async function renamePlayer(playerId: number, rawName: string): Promise<Player> {
   const trimmedName = rawName.trim();
   assertNameNotEmpty(trimmedName);
   assertNameWithinMaxLength(trimmedName);
@@ -20,6 +20,5 @@ export async function renamePlayer(discordId: string, fallbackName: string, rawN
   const sanitizedName = sanitizeName(trimmedName);
   assertNameNotEmpty(sanitizedName);
 
-  const { player } = await findOrCreatePlayer(discordId, fallbackName);
-  return playerRepository.updateName(player.id, sanitizedName);
+  return playerRepository.updateName(playerId, sanitizedName);
 }

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -14,7 +14,6 @@ export async function findOrCreatePlayer(discordId: string, name: string): Promi
 
 export async function renamePlayer(playerId: number, rawName: string): Promise<Player> {
   const trimmedName = rawName.trim();
-  assertNameNotEmpty(trimmedName);
   assertNameWithinMaxLength(trimmedName);
 
   const sanitizedName = sanitizeName(trimmedName);

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -1,5 +1,6 @@
 import type { Player } from '@one-piece/db';
 
+import { assertNameNotEmpty, assertNameWithinMaxLength, sanitizeName } from './name.js';
 import * as playerRepository from './repository.js';
 
 type FindOrCreateResult = { player: Player; created: boolean };
@@ -9,4 +10,16 @@ export async function findOrCreatePlayer(discordId: string, name: string): Promi
   if (existing) return { player: existing, created: false };
   const created = await playerRepository.create(discordId, name);
   return { player: created, created: true };
+}
+
+export async function renamePlayer(discordId: string, fallbackName: string, rawName: string): Promise<Player> {
+  const trimmedName = rawName.trim();
+  assertNameNotEmpty(trimmedName);
+  assertNameWithinMaxLength(trimmedName);
+
+  const sanitizedName = sanitizeName(trimmedName);
+  assertNameNotEmpty(sanitizedName);
+
+  const { player } = await findOrCreatePlayer(discordId, fallbackName);
+  return playerRepository.updateName(player.id, sanitizedName);
 }


### PR DESCRIPTION
## Résumé

Ajout de la commande `$rename <nom>` pour permettre à un player de modifier son nom après sa création initiale avec son username Discord.

La commande :
- récupère ou crée le player lié à l'utilisateur Discord ;
- vérifie que le nom n'est pas vide ;
- vérifie que le nom ne dépasse pas la limite de 64 caractères ;
- sanitize (désinfecte/nettoie) le nom avant de le stocker ;
- met à jour la colonne `name` du player ;
- confirme avec `Tu t'appelles maintenant <nouveau_nom>.`.

## Choix de sanitization

J'ai choisi une stratégie de blacklist plutôt qu'une whitelist.

L'idée est de garder une approche plus permissive et plus intuitive pour les joueurs : ils peuvent utiliser la plupart des caractères normaux dans leur pseudo, mais on retire ceux qui peuvent casser l'affichage Discord ou provoquer des effets indésirables, comme le markdown ou les mentions.

Ça évite par exemple que `Lu*ffy**` affiche du gras ou qu'un pseudo contenant `@everyone` déclenche une mention si le nom est réutilisé dans un message.

<img width="880" height="522" alt="image" src="https://github.com/user-attachments/assets/16d2d3f1-417c-451e-b1cb-561eb7e2bbd3" />

