### PR TITLE
feat(dev): add nombre button command

### DIFF
--- a/apps/bot/src/domains/_dev/commands/index.ts
+++ b/apps/bot/src/domains/_dev/commands/index.ts
@@ -1,7 +1,8 @@
 import { colorCommand } from './color.js';
 import { embedCommand } from './embed.js';
 import { moiCommand } from './moi.js';
+import { nombreCommand } from './nombre.js';
 import { onePieceCommand } from './onepiece.js';
 import { repeatCommand } from './repeat.js';
 
-export const devCommands = [onePieceCommand, repeatCommand, embedCommand, moiCommand, colorCommand];
+export const devCommands = [onePieceCommand, repeatCommand, embedCommand, moiCommand, colorCommand, nombreCommand];

--- a/apps/bot/src/domains/_dev/commands/nombre.ts
+++ b/apps/bot/src/domains/_dev/commands/nombre.ts
@@ -1,0 +1,68 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+
+import type { Command } from '../../../shared/command.js';
+import { DISCORD_ACTION_ROW_MAX_BUTTONS } from '../../../shared/constants.js';
+
+function getRandomInteger(min: number, max: number): number {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function getRandomIntegersExcluding(count: number, excludedNumbers: Array<number>): Array<number> {
+  const results: Array<number> = [];
+
+  while (results.length < count) {
+    const randomNumber = getRandomInteger(0, 100);
+
+    if (excludedNumbers.includes(randomNumber) || results.includes(randomNumber)) {
+      continue;
+    }
+
+    results.push(randomNumber);
+  }
+
+  return results;
+}
+
+function shuffleNumbers(numbers: Array<number>): Array<number> {
+  return numbers.sort(() => Math.random() - 0.5);
+}
+
+export const nombreCommand: Command = {
+  name: 'nombre',
+  async handler(message, args) {
+    const rawNumber = args[0];
+
+    if (!rawNumber) {
+      await message.reply('Tu dois donner un nombre.');
+      return;
+    }
+
+    const number = Number(rawNumber);
+
+    if (!Number.isFinite(number)) {
+      await message.reply('Tu dois donner un nombre valide.');
+      return;
+    }
+
+    if (!Number.isInteger(number)) {
+      await message.reply('Tu dois donner un nombre entier.');
+      return;
+    }
+
+    const randomNumbers = getRandomIntegersExcluding(DISCORD_ACTION_ROW_MAX_BUTTONS - 1, [number]);
+    const numbers = [number, ...randomNumbers];
+
+    const shuffledNumbers = shuffleNumbers(numbers);
+
+    const buttons = shuffledNumbers.map((value) =>
+      new ButtonBuilder().setCustomId(`nombre:${value}`).setLabel(String(value)).setStyle(ButtonStyle.Secondary),
+    );
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(buttons);
+
+    await message.reply({
+      content: 'Choisis le bon nombre :',
+      components: [row],
+    });
+  },
+};


### PR DESCRIPTION
## Résumé

Ajout de la commande `nombre <n>`.

La commande vérifie l'argument donné par l'utilisateur, puis répond avec une ActionRow contenant 5 boutons :
- 1 bouton avec le vrai nombre donné ;
- 4 boutons avec des nombres aléatoires ;
- les 5 boutons sont mélangés.

## Notes

Il n'y a pas de handler de clic volontairement, car ce ticket demande seulement d'afficher les boutons sans traiter l'interaction.

<img width="830" height="288" alt="image" src="https://github.com/user-attachments/assets/c09e91f9-9dbd-46d0-832c-6ca0277270e9" />

