### PR TITLE
introduction de createOPembed

### DIFF
--- a/apps/bot/src/domains/_dev/commands/color.ts
+++ b/apps/bot/src/domains/_dev/commands/color.ts
@@ -1,6 +1,5 @@
-import { EmbedBuilder } from 'discord.js';
-
 import type { Command } from '../../../shared/command.js';
+import { createOpEmbed } from '../../../shared/embed/create-op-embed.js';
 
 function getRandomColor(): number {
   return Math.floor(Math.random() * 0xffffff);
@@ -16,10 +15,7 @@ export const colorCommand: Command = {
     const color = getRandomColor();
     const hex = toHex(color);
 
-    const embed = new EmbedBuilder()
-      .setTitle('🎨 Couleur aléatoire')
-      .setDescription(`Couleur tirée au hasard : **${hex}**`)
-      .setColor(color);
+    const embed = createOpEmbed().setTitle('🎨 Couleur aléatoire').setDescription(`Couleur tirée au hasard : **${hex}**`).setColor(color);
 
     await message.reply({ embeds: [embed] });
   },

--- a/apps/bot/src/domains/_dev/commands/embed.ts
+++ b/apps/bot/src/domains/_dev/commands/embed.ts
@@ -1,13 +1,12 @@
-import { EmbedBuilder } from 'discord.js';
-
 import type { Command } from '../../../shared/command.js';
+import { createOpEmbed } from '../../../shared/embed/create-op-embed.js';
 
 export const embedCommand: Command = {
   name: 'embed',
   async handler(message) {
     const dateUnix = Math.floor(Date.now() / 1000);
 
-    const embed = new EmbedBuilder()
+    const embed = createOpEmbed()
       .setAuthor({
         name: 'Author: name (cliquable)',
         iconURL: 'https://placehold.co/64x64/5865F2/FFFFFF.png?text=A',

--- a/apps/bot/src/domains/_dev/commands/moi.ts
+++ b/apps/bot/src/domains/_dev/commands/moi.ts
@@ -1,6 +1,5 @@
-import { EmbedBuilder } from 'discord.js';
-
 import type { Command } from '../../../shared/command.js';
+import { createOpEmbed } from '../../../shared/embed/create-op-embed.js';
 
 // TODO: supprimer avant la prod
 export const moiCommand: Command = {
@@ -8,7 +7,7 @@ export const moiCommand: Command = {
   async handler(message) {
     const targetUser = message.mentions.users.first();
     const user = targetUser ?? message.author;
-    const embed = new EmbedBuilder()
+    const embed = createOpEmbed()
       .setAuthor({
         name: user.username,
         iconURL: user.displayAvatarURL(),

--- a/apps/bot/src/domains/devil_fruit/ui.ts
+++ b/apps/bot/src/domains/devil_fruit/ui.ts
@@ -1,8 +1,9 @@
 import type { DevilFruitTemplate } from '@one-piece/db';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type EmbedBuilder } from 'discord.js';
 
 import { buildAssetUrl } from '../../shared/assets.js';
 import { DISCORD_BUTTON_LABEL_MAX_LENGTH } from '../../shared/constants.js';
+import { createOpEmbed } from '../../shared/embed/create-op-embed.js';
 import { truncate } from '../../shared/helpers.js';
 
 export const INFO_CUSTOM_ID_PREFIX = 'info:devil_fruit:';
@@ -18,10 +19,9 @@ export function buildDisambiguationRow(fruits: Array<DevilFruitTemplate>): Actio
 }
 
 export function buildInfoEmbed(fruit: DevilFruitTemplate): EmbedBuilder {
-  const embed = new EmbedBuilder()
+  const embed = createOpEmbed()
     .setTitle(fruit.name)
     // TODO: Il faudrait que chaque fruit ait sa propre couleur plus tard (ajouter colonne color etc..)
-    .setColor(0x5865f2)
     .addFields(
       {
         // TODO: Il faudrait que types prennent un S seulement si c'est au pluriel (plusieurs types)

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -2,6 +2,7 @@ import { Client, Events, GatewayIntentBits } from 'discord.js';
 
 import { routeInteraction } from './discord/interactionRouter.js';
 import { routeMessage } from './discord/router.js';
+import { setBotIconUrl } from './shared/embed/branding.js';
 
 const token = process.env.DISCORD_TOKEN;
 if (!token) {
@@ -18,6 +19,7 @@ const client = new Client({
 });
 
 client.once(Events.ClientReady, (c) => {
+  setBotIconUrl(c.user.displayAvatarURL());
   console.log(`Bot connecté : ${c.user.tag}`);
 });
 

--- a/apps/bot/src/shared/embed/branding.ts
+++ b/apps/bot/src/shared/embed/branding.ts
@@ -1,0 +1,8 @@
+// TODO: Décider la bonne couleur et le bon nom pour le bot discord
+export const BOT_NAME = 'One Piece Bot';
+export const BOT_COLOR = 0xffcd29;
+export let botIconUrl: string | undefined;
+
+export function setBotIconUrl(url: string): void {
+  botIconUrl = url;
+}

--- a/apps/bot/src/shared/embed/create-op-embed.ts
+++ b/apps/bot/src/shared/embed/create-op-embed.ts
@@ -1,0 +1,7 @@
+import { EmbedBuilder } from 'discord.js';
+
+import { BOT_COLOR, BOT_NAME, botIconUrl } from './branding.js';
+
+export function createOpEmbed(): EmbedBuilder {
+  return new EmbedBuilder().setColor(BOT_COLOR).setAuthor({ name: BOT_NAME, iconURL: botIconUrl });
+}


### PR DESCRIPTION
## Résumé
- Nouvelle fonction (ce qu'on appelle une fonction factory (usine) ) `createOpEmbed()` qui pré-remplit couleur + author du bot pour éviter de répéter ces réglages sur chaque embed (lire l'issue #80).
- Les 4 call sites  (call sites = les endroits qui appellent cette fonction) existants (`devil_fruit/ui.ts`, `_dev/moi`, `_dev/embed`, `_dev/color`) passent par cette fonction, on peut toujours **override** chaque propriété restent possibles via setAuthor.. setColor...
- Le branding est regroupé dans `shared/embed/branding.ts` (branding = marque, c'est un terme souvent utilisé pour décrire tout ce qui est relatif au design) : on a `BOT_NAME`, `BOT_COLOR` en const, et `botIconUrl` c'est pas une const car enft c'est récupéré depuis discord quand on le bot se connecte (faites pas attention, je vous expliquerai en appel)

## Exemples : 
-  Désormais il y a One Piece bot avec la PP, (et normalement la couleur, mais là la commande SUR ECRIt (overwrite) la couleur par défaut via .setColor(..)
<img width="355" height="180" alt="image" src="https://github.com/user-attachments/assets/0b8c8f9b-4ca6-4157-9fdb-7d14224a7bb3" />

