### PR TITLE
83 feature config ship modules valeurs coûts par niveau

### DIFF
--- a/apps/bot/src/domains/ship/modules.ts
+++ b/apps/bot/src/domains/ship/modules.ts
@@ -1,15 +1,16 @@
 import type { ResourceName, ShipModuleKey } from '@one-piece/db';
 
 type UpgradeCost = {
-  berry: number;
-  resources: Partial<Record<ResourceName, number>>;
+  berry?: number;
+  resources?: Partial<Record<ResourceName, number>>;
 };
 
 type ShipModuleConfig = {
-  valueByLevel: ReadonlyArray<number>;
-  costByLevel: ReadonlyArray<UpgradeCost>;
+  valueByLevel: Array<number>;
+  costByLevel: Array<UpgradeCost>;
 };
 
+// TODO: Équilibrer les valeurs, ajouter des vrais ressources
 export const SHIP_MODULES = {
   hull: {
     valueByLevel: [100, 150, 220, 320, 450],

--- a/apps/bot/src/domains/ship/modules.ts
+++ b/apps/bot/src/domains/ship/modules.ts
@@ -1,0 +1,59 @@
+import type { ResourceName, ShipModuleKey } from '@one-piece/db';
+
+type UpgradeCost = {
+  berry: number;
+  resources: Partial<Record<ResourceName, number>>;
+};
+
+type ShipModuleConfig = {
+  valueByLevel: ReadonlyArray<number>;
+  costByLevel: ReadonlyArray<UpgradeCost>;
+};
+
+export const SHIP_MODULES = {
+  hull: {
+    valueByLevel: [100, 150, 220, 320, 450],
+    costByLevel: [
+      { berry: 500, resources: { Bois: 10 } },
+      { berry: 1500, resources: { Bois: 25, Fer: 5 } },
+      { berry: 4000, resources: { Bois: 50, Fer: 15 } },
+      { berry: 10000, resources: { Bois: 100, Fer: 40 } },
+    ],
+  },
+  sail: {
+    valueByLevel: [10, 14, 18, 23, 28],
+    costByLevel: [
+      { berry: 400, resources: { Bois: 8 } },
+      { berry: 1200, resources: { Bois: 20 } },
+      { berry: 3500, resources: { Bois: 45, Fer: 10 } },
+      { berry: 9000, resources: { Bois: 90, Fer: 30 } },
+    ],
+  },
+  decks: {
+    valueByLevel: [3, 4, 5, 6, 7],
+    costByLevel: [
+      { berry: 800, resources: { Bois: 15 } },
+      { berry: 2500, resources: { Bois: 35, Fer: 8 } },
+      { berry: 7000, resources: { Bois: 70, Fer: 25 } },
+      { berry: 18000, resources: { Bois: 140, Fer: 60 } },
+    ],
+  },
+  cabins: {
+    valueByLevel: [2, 4, 6, 9, 12],
+    costByLevel: [
+      { berry: 600, resources: { Bois: 12 } },
+      { berry: 1800, resources: { Bois: 30, Fer: 5 } },
+      { berry: 5000, resources: { Bois: 60, Fer: 18 } },
+      { berry: 13000, resources: { Bois: 120, Fer: 45 } },
+    ],
+  },
+  cargo: {
+    valueByLevel: [20, 35, 55, 80, 110],
+    costByLevel: [
+      { berry: 500, resources: { Bois: 12 } },
+      { berry: 1500, resources: { Bois: 28, Fer: 6 } },
+      { berry: 4200, resources: { Bois: 55, Fer: 20 } },
+      { berry: 11000, resources: { Bois: 110, Fer: 50 } },
+    ],
+  },
+} as const satisfies Record<ShipModuleKey, ShipModuleConfig>;

--- a/packages/db/src/domains/resource/index.ts
+++ b/packages/db/src/domains/resource/index.ts
@@ -1,2 +1,3 @@
+export type { ResourceName } from './resource_template/data.js';
 export { seedResources } from './resource_template/seed.js';
 export { resourceTemplate, type ResourceTemplate, type ResourceTemplateInsert } from './resource_template/schema.js';

--- a/packages/db/src/domains/resource/resource_template/data.ts
+++ b/packages/db/src/domains/resource/resource_template/data.ts
@@ -1,6 +1,6 @@
 import type { ResourceTemplateInsert } from './schema.js';
 
-export const RESOURCE_TEMPLATES_DATA: Array<ResourceTemplateInsert> = [
+export const RESOURCE_TEMPLATES_DATA = [
   {
     name: 'Bois',
     imageUrl: null,
@@ -9,4 +9,6 @@ export const RESOURCE_TEMPLATES_DATA: Array<ResourceTemplateInsert> = [
     name: 'Fer',
     imageUrl: null,
   },
-];
+] as const satisfies ReadonlyArray<ResourceTemplateInsert>;
+
+export type ResourceName = (typeof RESOURCE_TEMPLATES_DATA)[number]['name'];

--- a/packages/db/src/domains/resource/resource_template/seed.ts
+++ b/packages/db/src/domains/resource/resource_template/seed.ts
@@ -9,7 +9,7 @@ import { resourceTemplate } from './schema.js';
 export async function seedResources(db: Db) {
   await db
     .insert(resourceTemplate)
-    .values(RESOURCE_TEMPLATES_DATA)
+    .values([...RESOURCE_TEMPLATES_DATA])
     .onConflictDoUpdate({
       target: resourceTemplate.name,
       set: {

--- a/packages/db/src/domains/ship/index.ts
+++ b/packages/db/src/domains/ship/index.ts
@@ -1,1 +1,1 @@
-export { ship, type Ship } from './schema.js';
+export { ship, type Ship, type ShipModuleKey } from './schema.js';

--- a/packages/db/src/domains/ship/schema.ts
+++ b/packages/db/src/domains/ship/schema.ts
@@ -25,3 +25,5 @@ export const ship = pgTable('ship', {
 });
 
 export type Ship = typeof ship.$inferSelect;
+
+export type ShipModuleKey = 'hull' | 'sail' | 'decks' | 'cabins' | 'cargo';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,5 +2,5 @@ export { closeDb, db, type Db } from './client.js';
 export * from './schema.js';
 export { type Player } from './domains/player/index.js';
 export { type DevilFruitTemplate } from './domains/devil_fruit/index.js';
-export { type Ship } from './domains/ship/index.js';
+export { type Ship, type ShipModuleKey } from './domains/ship/index.js';
 export { type ResourceName, type ResourceTemplate } from './domains/resource/index.js';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,4 +3,4 @@ export * from './schema.js';
 export { type Player } from './domains/player/index.js';
 export { type DevilFruitTemplate } from './domains/devil_fruit/index.js';
 export { type Ship } from './domains/ship/index.js';
-export { type ResourceTemplate } from './domains/resource/index.js';
+export { type ResourceName, type ResourceTemplate } from './domains/resource/index.js';


### PR DESCRIPTION
## Résumé
- Nouvelle configuration `SHIP_MODULES` (`apps/bot/src/domains/ship/modules.ts`) qui donne pour chacun des 5 modules (`hull`, `sail`, `decks`, `cabins`, `cargo`) la valeur par niveau et le coût pour upgrade. on a désormais une source de vérité pour répondre à "maxHp au niveau 3 ?" et "ça coûte combien de passer sail 2 → 3 ?"