### PR TITLE
feature(profile): implement registry + view + router

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,7 @@
+if [ ! -f node_modules/.modules.yaml ] || [ pnpm-lock.yaml -nt node_modules/.modules.yaml ]; then
+  echo "📦 Lockfile changed — running pnpm install…"
+  pnpm install
+fi
+
 pnpm lint-staged
 pnpm typecheck

--- a/apps/bot/src/discord/constants.ts
+++ b/apps/bot/src/discord/constants.ts
@@ -2,3 +2,4 @@ export const DISCORD_BUTTON_LABEL_MAX_LENGTH = 80;
 export const DISCORD_SELECT_OPTION_LABEL_MAX_LENGTH = 100;
 export const DISCORD_CUSTOM_ID_MAX_LENGTH = 100;
 export const DISCORD_ACTION_ROW_MAX_BUTTONS = 5; // Maximum 5 boutons par ligne d'action selon leur doc
+export const CUSTOM_ID_SEPARATOR = ':';

--- a/apps/bot/src/discord/interactionRouter.ts
+++ b/apps/bot/src/discord/interactionRouter.ts
@@ -2,7 +2,9 @@ import type { Interaction } from 'discord.js';
 
 import { devilFruitButtonHandlers } from '../domains/devil_fruit/index.js';
 
-const allButtonHandlers = [...devilFruitButtonHandlers];
+import { menuButtonHandler } from './menu/index.js';
+
+const allButtonHandlers = [...devilFruitButtonHandlers, menuButtonHandler];
 
 /** Dispatche une interaction vers le bon handler. Voir `docs/discord.md`. */
 export async function routeInteraction(interaction: Interaction): Promise<void> {

--- a/apps/bot/src/discord/menu/buttons/build-navigation-row.ts
+++ b/apps/bot/src/discord/menu/buttons/build-navigation-row.ts
@@ -1,0 +1,17 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+
+import { CUSTOM_ID_SEPARATOR } from '../../constants.js';
+import { allMenuViews, type MenuViewKey } from '../views/registry.js';
+
+export function buildNavigationRow(currentKey: MenuViewKey, playerId: number): ActionRowBuilder<ButtonBuilder> {
+  const buttons = allMenuViews.map((view) => {
+    const btn = new ButtonBuilder()
+      .setCustomId(['menu', view.key, playerId].join(CUSTOM_ID_SEPARATOR))
+      .setLabel(view.label)
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(view.key === currentKey)
+      .setEmoji(view.emoji);
+    return btn;
+  });
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(buttons);
+}

--- a/apps/bot/src/discord/menu/buttons/handler.ts
+++ b/apps/bot/src/discord/menu/buttons/handler.ts
@@ -1,0 +1,22 @@
+import type { ButtonInteraction } from 'discord.js';
+
+import { CUSTOM_ID_SEPARATOR } from '../../constants.js';
+import type { ButtonHandler } from '../../types.js';
+import { buildMenuView } from '../views/index.js';
+import { type MenuViewKey } from '../views/registry.js';
+
+async function handle(interaction: ButtonInteraction): Promise<void> {
+  await interaction.deferUpdate();
+  const [, viewKey, playerIdStr] = interaction.customId.split(CUSTOM_ID_SEPARATOR);
+  const playerId = Number(playerIdStr);
+  if (!viewKey || !Number.isInteger(playerId)) {
+    throw new Error(`customId menu malformé: ${interaction.customId}`);
+  }
+  const view = await buildMenuView(viewKey as MenuViewKey, playerId);
+  await interaction.editReply(view);
+}
+
+export const menuButtonHandler: ButtonHandler = {
+  customIdPrefix: `menu${CUSTOM_ID_SEPARATOR}`,
+  handle,
+};

--- a/apps/bot/src/discord/menu/buttons/index.ts
+++ b/apps/bot/src/discord/menu/buttons/index.ts
@@ -1,0 +1,2 @@
+export { menuButtonHandler } from './handler.js';
+export { buildNavigationRow } from './build-navigation-row.js';

--- a/apps/bot/src/discord/menu/index.ts
+++ b/apps/bot/src/discord/menu/index.ts
@@ -1,0 +1,2 @@
+export * from './buttons/index.js';
+export * from './views/index.js';

--- a/apps/bot/src/discord/menu/views/build-menu-view.ts
+++ b/apps/bot/src/discord/menu/views/build-menu-view.ts
@@ -1,0 +1,10 @@
+import { buildNavigationRow } from '../buttons/build-navigation-row.js';
+
+import { type MenuViewKey, viewsByKey } from './registry.js';
+
+export async function buildMenuView(key: MenuViewKey, playerId: number) {
+  const view = viewsByKey.get(key);
+  if (!view) throw new Error(`Vue inconnue : ${key}`);
+  const embed = await view.build(playerId);
+  return { embeds: [embed], components: [buildNavigationRow(key, playerId)] };
+}

--- a/apps/bot/src/discord/menu/views/index.ts
+++ b/apps/bot/src/discord/menu/views/index.ts
@@ -1,0 +1,2 @@
+export { buildMenuView } from './build-menu-view.js';
+export type { MenuView } from './types.js';

--- a/apps/bot/src/discord/menu/views/registry.ts
+++ b/apps/bot/src/discord/menu/views/registry.ts
@@ -1,0 +1,15 @@
+import { profilMenuView } from '../../../domains/player/profil-menu-view.js';
+import { shipMenuView } from '../../../domains/ship/ship-menu-view.js';
+import { DISCORD_ACTION_ROW_MAX_BUTTONS } from '../../constants.js';
+
+import type { MenuView } from './types.js';
+
+export const allMenuViews = [profilMenuView, shipMenuView];
+
+if (allMenuViews.length > DISCORD_ACTION_ROW_MAX_BUTTONS) {
+  throw new Error('Le menu est trop grand.');
+}
+
+export type MenuViewKey = (typeof allMenuViews)[number]['key'];
+
+export const viewsByKey = new Map<MenuViewKey, MenuView>(allMenuViews.map((v) => [v.key, v]));

--- a/apps/bot/src/discord/menu/views/types.ts
+++ b/apps/bot/src/discord/menu/views/types.ts
@@ -1,0 +1,10 @@
+import type { EmbedBuilder } from 'discord.js';
+
+export type MenuView = {
+  /** Identifiant UNIQUE qui permet de retrouver cette vue via une interaction */
+  key: string;
+  label: string;
+  emoji?: string;
+  /** Construit l'embed de la vue à partir du playerId. */
+  build: (playerId: number) => Promise<EmbedBuilder>;
+};

--- a/apps/bot/src/domains/economy/constants.ts
+++ b/apps/bot/src/domains/economy/constants.ts
@@ -1,0 +1,1 @@
+export const BERRY_SYMBOL = '฿';

--- a/apps/bot/src/domains/economy/format.ts
+++ b/apps/bot/src/domains/economy/format.ts
@@ -1,3 +1,0 @@
-export function formatBerry(amount: bigint | number): string {
-  return `${amount.toLocaleString('fr-FR')} 💰`;
-}

--- a/apps/bot/src/domains/economy/index.ts
+++ b/apps/bot/src/domains/economy/index.ts
@@ -1,1 +1,1 @@
-export { formatBerry } from './format.js';
+export { formatBerry } from './utils/format-berry.js';

--- a/apps/bot/src/domains/economy/utils/format-berry.ts
+++ b/apps/bot/src/domains/economy/utils/format-berry.ts
@@ -1,0 +1,5 @@
+import { BERRY_SYMBOL } from '../constants.js';
+
+export function formatBerry(amount: bigint | number): string {
+  return `${amount.toLocaleString('fr-FR')} ${BERRY_SYMBOL}`;
+}

--- a/apps/bot/src/domains/player/commands/index.ts
+++ b/apps/bot/src/domains/player/commands/index.ts
@@ -1,4 +1,5 @@
 import { debugCommand } from './debug.js';
 import { karmaCommand } from './karma.js';
+import { profilCommand } from './profil.js';
 
-export const playerCommands = [karmaCommand, debugCommand];
+export const playerCommands = [karmaCommand, debugCommand, profilCommand];

--- a/apps/bot/src/domains/player/commands/profil.ts
+++ b/apps/bot/src/domains/player/commands/profil.ts
@@ -1,0 +1,14 @@
+import { buildMenuView } from '../../../discord/menu/index.js';
+import type { Command } from '../../../discord/types.js';
+import { getTargetUser } from '../../../discord/utils/get-target-user.js';
+import { findOrCreatePlayer } from '../service.js';
+
+export const profilCommand: Command = {
+  name: 'profil',
+  async handler(message) {
+    const target = getTargetUser(message);
+    const { player } = await findOrCreatePlayer(target.id, target.username);
+    const view = await buildMenuView('profil', player.id);
+    await message.reply(view);
+  },
+};

--- a/apps/bot/src/domains/player/profil-menu-view.ts
+++ b/apps/bot/src/domains/player/profil-menu-view.ts
@@ -1,0 +1,28 @@
+import type { EmbedBuilder } from 'discord.js';
+
+import { createOpEmbed } from '../../discord/embed/create-op-embed.js';
+import type { MenuView } from '../../discord/menu/views/index.js';
+import { formatBerry } from '../economy/utils/format-berry.js';
+
+import { getKarmaGrade } from './karma.js';
+import { findById } from './repository.js';
+
+async function build(playerId: number): Promise<EmbedBuilder> {
+  const player = await findById(playerId);
+  if (!player) {
+    return createOpEmbed().setDescription('Joueur introuvable.');
+  }
+  return createOpEmbed()
+    .setTitle(`Profil de ${player.name}`)
+    .addFields(
+      { name: '💰 Bounty', value: formatBerry(player.bounty), inline: true },
+      { name: '⚖️ Karma', value: `${player.karma} (${getKarmaGrade(player.karma)})`, inline: true },
+    );
+}
+
+export const profilMenuView = {
+  key: 'profil',
+  label: 'Profil',
+  emoji: '👤',
+  build,
+} as const satisfies MenuView;

--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -1,6 +1,11 @@
 import { db, player, type Player } from '@one-piece/db';
 import { eq } from 'drizzle-orm';
 
+export async function findById(id: number): Promise<Player | undefined> {
+  const [row] = await db.select().from(player).where(eq(player.id, id)).limit(1);
+  return row;
+}
+
 export async function findByDiscordId(discordId: string): Promise<Player | undefined> {
   const [row] = await db.select().from(player).where(eq(player.discordId, discordId)).limit(1);
   return row;

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -11,6 +11,7 @@ export async function findOrCreatePlayer(discordId: string, name: string): Promi
   const existing = await playerRepository.findByDiscordId(discordId);
   if (existing) return { player: existing, created: false };
   const created = await playerRepository.create(discordId, name);
+  // TODO: ajouter tout ça dans une transaction
   await findOrCreateShip(created.id);
   return { player: created, created: true };
 }

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -1,5 +1,7 @@
 import type { Player } from '@one-piece/db';
 
+import { findOrCreateShip } from '../ship/service.js';
+
 import * as playerRepository from './repository.js';
 
 type FindOrCreateResult = { player: Player; created: boolean };
@@ -8,5 +10,6 @@ export async function findOrCreatePlayer(discordId: string, name: string): Promi
   const existing = await playerRepository.findByDiscordId(discordId);
   if (existing) return { player: existing, created: false };
   const created = await playerRepository.create(discordId, name);
+  await findOrCreateShip(created.id);
   return { player: created, created: true };
 }

--- a/apps/bot/src/domains/ship/commands/ship.ts
+++ b/apps/bot/src/domains/ship/commands/ship.ts
@@ -1,19 +1,14 @@
-import { EmbedBuilder } from 'discord.js';
-
+import { buildMenuView } from '../../../discord/menu/index.js';
 import type { Command } from '../../../discord/types.js';
+import { getTargetUser } from '../../../discord/utils/get-target-user.js';
 import { findOrCreatePlayer } from '../../player/service.js';
-import { findOrCreateShip } from '../service.js';
 
 export const shipCommand: Command = {
   name: 'ship',
   async handler(message) {
-    // TODO: remplacer par helper
-    const targetUser = message.mentions.users.first();
-    const finalUser = targetUser ?? message.author;
-    const { player } = await findOrCreatePlayer(finalUser.id, finalUser.username);
-    const { ship } = await findOrCreateShip(player.id);
-    // TODO: remplacer par CreateOpEmbed un jour ou l'autre
-    const embed = new EmbedBuilder().setTitle(ship.name);
-    await message.reply({ embeds: [embed] });
+    const user = getTargetUser(message);
+    const { player } = await findOrCreatePlayer(user.id, user.username);
+    const view = await buildMenuView('ship', player.id);
+    await message.reply(view);
   },
 };

--- a/apps/bot/src/domains/ship/ship-menu-view.ts
+++ b/apps/bot/src/domains/ship/ship-menu-view.ts
@@ -13,6 +13,7 @@ async function build(playerId: number): Promise<EmbedBuilder> {
     return createOpEmbed().setDescription("Ce joueur n'a pas encore de navire.");
   }
   const embed = createOpEmbed().setTitle(`🚢 ${ship.name}`).setDescription(`HP : ${ship.hp}`);
+  // TODO: Redesign this shit
   for (const key of SHIP_MODULE_KEYS) {
     const level = ship[SHIP_MODULE_LEVEL_COLUMNS[key]];
     const value = SHIP_MODULES[key].valueByLevel[level - 1];

--- a/apps/bot/src/domains/ship/ship-menu-view.ts
+++ b/apps/bot/src/domains/ship/ship-menu-view.ts
@@ -1,0 +1,41 @@
+import { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type ShipModuleKey } from '@one-piece/db';
+import type { EmbedBuilder } from 'discord.js';
+
+import { createOpEmbed } from '../../discord/embed/create-op-embed.js';
+import type { MenuView } from '../../discord/menu/views/index.js';
+
+import { SHIP_MODULES } from './modules.js';
+import { findByPlayerId } from './repository.js';
+
+async function build(playerId: number): Promise<EmbedBuilder> {
+  const ship = await findByPlayerId(playerId);
+  if (!ship) {
+    return createOpEmbed().setDescription("Ce joueur n'a pas encore de navire.");
+  }
+  const embed = createOpEmbed().setTitle(`🚢 ${ship.name}`).setDescription(`HP : ${ship.hp}`);
+  for (const key of SHIP_MODULE_KEYS) {
+    const level = ship[SHIP_MODULE_LEVEL_COLUMNS[key]];
+    const value = SHIP_MODULES[key].valueByLevel[level - 1];
+    embed.addFields({
+      name: `${MODULE_LABELS[key]} (niveau ${level})`,
+      value: value !== undefined ? String(value) : '—',
+      inline: true,
+    });
+  }
+  return embed;
+}
+
+export const shipMenuView = {
+  key: 'ship',
+  label: 'Navire',
+  emoji: '🚢',
+  build,
+} as const satisfies MenuView;
+
+const MODULE_LABELS: Record<ShipModuleKey, string> = {
+  hull: 'Coque',
+  sail: 'Voile',
+  decks: 'Ponts',
+  cabins: 'Chambres',
+  cargo: 'Cale',
+};

--- a/packages/db/src/domains/ship/index.ts
+++ b/packages/db/src/domains/ship/index.ts
@@ -1,1 +1,1 @@
-export { ship, type Ship, type ShipModuleKey } from './schema.js';
+export { ship, SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type Ship, type ShipModuleKey } from './schema.js';

--- a/packages/db/src/domains/ship/schema.ts
+++ b/packages/db/src/domains/ship/schema.ts
@@ -26,4 +26,16 @@ export const ship = pgTable('ship', {
 
 export type Ship = typeof ship.$inferSelect;
 
-export type ShipModuleKey = 'hull' | 'sail' | 'decks' | 'cabins' | 'cargo';
+export const SHIP_MODULE_KEYS = ['hull', 'sail', 'decks', 'cabins', 'cargo'] as const;
+
+export type ShipModuleKey = (typeof SHIP_MODULE_KEYS)[number];
+
+type ShipLevelColumn = 'hullLevel' | 'sailLevel' | 'decksLevel' | 'cabinsLevel' | 'cargoLevel';
+
+export const SHIP_MODULE_LEVEL_COLUMNS: Record<ShipModuleKey, ShipLevelColumn> = {
+  hull: 'hullLevel',
+  sail: 'sailLevel',
+  decks: 'decksLevel',
+  cabins: 'cabinsLevel',
+  cargo: 'cargoLevel',
+};

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,5 +2,5 @@ export { closeDb, db, type Db } from './client.js';
 export * from './schema.js';
 export { type Player } from './domains/player/index.js';
 export { type DevilFruitTemplate } from './domains/devil_fruit/index.js';
-export { type Ship, type ShipModuleKey } from './domains/ship/index.js';
+export { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type Ship, type ShipModuleKey } from './domains/ship/index.js';
 export { type ResourceName, type ResourceTemplate } from './domains/resource/index.js';


### PR DESCRIPTION
## Résumé
- Nouvelle commande `!profil` qui ouvre un menu navigable avec embed + boutons (Profil, Navire), chaque clic re-render l'embed sans recréer le message (closes #96).
- Architecture menu dans `discord/menu/` : `views/registry.ts` liste toutes les vues (type-safe via `as const satisfies`, garde contre le max 5 boutons), `buttons/` gère la nav row et le handler unique `menu:<viewKey>:<playerId>`. Chaque domaine expose juste sa view (`profil-menu-view.ts`, `ship-menu-view.ts`), l'aggrégation vit côté menu.
- Gros nettoyage `shared/` → `discord/` : `command.ts` + `button-handler.ts` fusionnés dans `discord/types.ts`, `constants.ts` + `embed/` + `get-target-user.ts` migrés côté `discord/`, `shared/` ne garde que les pures utils (`utils.ts`, `build-asset-url.ts`).
- Côté DB : export de `SHIP_MODULE_KEYS` (array source de vérité dont dérive `ShipModuleKey`) et `SHIP_MODULE_LEVEL_COLUMNS` (mapping `hull → hullLevel`) pour que la view ship itère sans `Object.keys(... as ...)`.
- `findOrCreatePlayer` crée aussi le ship à la volée — un joueur a toujours un bateau, invariant appliqué au service plutôt que dupliqué sur chaque call site.