### PR TITLE
refactor(bot): standardize entity info embeds and search repositories

### DIFF
--- a/apps/bot/src/domains/character/build-info-embed.ts
+++ b/apps/bot/src/domains/character/build-info-embed.ts
@@ -1,0 +1,19 @@
+import type { CharacterTemplate } from '@one-piece/db';
+import type { EmbedBuilder } from 'discord.js';
+
+import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildAssetUrl } from '../../shared/build-asset-url.js';
+
+// TODO: ajouter une colonne `description` à character_template (ticket à créer) puis la rendre ici via setDescription
+// TODO: design de l'embed character à revoir (emojis, couleur, mise en forme HP/Combat)
+export function buildCharacterInfoEmbed(template: CharacterTemplate): EmbedBuilder {
+  const embed = buildOpEmbed()
+    .setTitle(template.name)
+    .addFields({ name: 'HP', value: String(template.hp), inline: true }, { name: 'Combat', value: String(template.combat), inline: true });
+
+  if (template.imageUrl) {
+    embed.setThumbnail(buildAssetUrl(template.imageUrl));
+  }
+
+  return embed;
+}

--- a/apps/bot/src/domains/character/repository.ts
+++ b/apps/bot/src/domains/character/repository.ts
@@ -1,0 +1,16 @@
+import { characterTemplate, db, type CharacterTemplate } from '@one-piece/db';
+import { eq, ilike, or, sql } from 'drizzle-orm';
+
+export async function searchManyByName(query: string): Promise<Array<CharacterTemplate>> {
+  return db
+    .select()
+    .from(characterTemplate)
+    .where(or(sql`${characterTemplate.name} % ${query}`, ilike(characterTemplate.name, `%${query}%`)))
+    .orderBy(sql`similarity(${characterTemplate.name}, ${query}) desc`)
+    .limit(25);
+}
+
+export async function findById(id: number): Promise<CharacterTemplate | undefined> {
+  const [row] = await db.select().from(characterTemplate).where(eq(characterTemplate.id, id)).limit(1);
+  return row;
+}

--- a/apps/bot/src/domains/devil_fruit/build-info-embed.ts
+++ b/apps/bot/src/domains/devil_fruit/build-info-embed.ts
@@ -1,0 +1,32 @@
+import type { DevilFruitTemplate } from '@one-piece/db';
+import type { EmbedBuilder } from 'discord.js';
+
+import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildAssetUrl } from '../../shared/build-asset-url.js';
+
+export function buildDevilFruitInfoEmbed(fruit: DevilFruitTemplate): EmbedBuilder {
+  const embed = buildOpEmbed()
+    .setTitle(fruit.name)
+    // TODO: Il faudrait que chaque fruit ait sa propre couleur plus tard (ajouter colonne color etc..)
+    .addFields(
+      // TODO: Il faudrait que types prennent un S seulement si c'est au pluriel (plusieurs types)
+      {
+        name: 'Types',
+        value: fruit.types.length > 0 ? fruit.types.join(', ') : '—',
+        inline: true,
+      },
+      // TODO: Il faut styliser ça et ajouter des emojis
+      { name: 'HP', value: formatDfBonus(fruit.hpBonus), inline: true },
+      { name: 'Combat', value: formatDfBonus(fruit.combatBonus), inline: true },
+    );
+
+  if (fruit.imageUrl) {
+    embed.setThumbnail(buildAssetUrl(fruit.imageUrl));
+  }
+
+  return embed;
+}
+
+function formatDfBonus(value: number): string {
+  return value >= 0 ? `+${value}` : String(value);
+}

--- a/apps/bot/src/domains/devil_fruit/commands/info.ts
+++ b/apps/bot/src/domains/devil_fruit/commands/info.ts
@@ -1,7 +1,8 @@
 import { DISCORD_ACTION_ROW_MAX_BUTTONS } from '../../../discord/constants.js';
 import type { Command } from '../../../discord/types.js';
+import { buildDevilFruitInfoEmbed } from '../build-info-embed.js';
 import { searchManyByName } from '../repository.js';
-import { buildDisambiguationRow, buildInfoEmbed } from '../ui.js';
+import { buildDisambiguationRow } from '../ui.js';
 
 export const infoCommand: Command = {
   name: 'info',
@@ -18,7 +19,7 @@ export const infoCommand: Command = {
       return;
     }
     if (rest.length === 0) {
-      await message.reply({ embeds: [buildInfoEmbed(fruit)] });
+      await message.reply({ embeds: [buildDevilFruitInfoEmbed(fruit)] });
       return;
     }
     if (fruits.length <= DISCORD_ACTION_ROW_MAX_BUTTONS) {

--- a/apps/bot/src/domains/devil_fruit/interactions/info-button.ts
+++ b/apps/bot/src/domains/devil_fruit/interactions/info-button.ts
@@ -1,11 +1,13 @@
 import type { ButtonInteraction } from 'discord.js';
 
 import type { ButtonHandler } from '../../../discord/types.js';
+import { buildDevilFruitInfoEmbed } from '../build-info-embed.js';
 import { findById } from '../repository.js';
-import { buildInfoEmbed, INFO_BUTTON_NAME } from '../ui.js';
+import { INFO_BUTTON_NAME } from '../ui.js';
 
 async function handle(interaction: ButtonInteraction, args: Array<string>): Promise<void> {
   const id = Number(args[0]);
+  // TODO: Ajouter un helper qui valide les identifiants
   if (!Number.isInteger(id)) return;
 
   await interaction.deferReply();
@@ -15,7 +17,7 @@ async function handle(interaction: ButtonInteraction, args: Array<string>): Prom
     await interaction.editReply({ content: "Ce fruit n'existe plus.", embeds: [], components: [] });
     return;
   }
-  await interaction.editReply({ content: '', embeds: [buildInfoEmbed(fruit)], components: [] });
+  await interaction.editReply({ content: '', embeds: [buildDevilFruitInfoEmbed(fruit)], components: [] });
 }
 
 export const infoButtonHandler: ButtonHandler = {

--- a/apps/bot/src/domains/devil_fruit/ui.ts
+++ b/apps/bot/src/domains/devil_fruit/ui.ts
@@ -1,14 +1,13 @@
 import type { DevilFruitTemplate } from '@one-piece/db';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type EmbedBuilder } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 
 import { DISCORD_BUTTON_LABEL_MAX_LENGTH } from '../../discord/constants.js';
 import { buildCustomId } from '../../discord/utils/build-custom-id.js';
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
-import { buildAssetUrl } from '../../shared/build-asset-url.js';
 import { truncate } from '../../shared/utils.js';
 
 export const INFO_BUTTON_NAME = 'infofruit';
 
+// TODO: Replace with shared info architecture
 export function buildDisambiguationRow(fruits: Array<DevilFruitTemplate>): ActionRowBuilder<ButtonBuilder> {
   const buttons = fruits.map((fruit) =>
     new ButtonBuilder()
@@ -17,31 +16,4 @@ export function buildDisambiguationRow(fruits: Array<DevilFruitTemplate>): Actio
       .setStyle(ButtonStyle.Primary),
   );
   return new ActionRowBuilder<ButtonBuilder>().addComponents(buttons);
-}
-
-export function buildInfoEmbed(fruit: DevilFruitTemplate): EmbedBuilder {
-  const embed = buildOpEmbed()
-    .setTitle(fruit.name)
-    // TODO: Il faudrait que chaque fruit ait sa propre couleur plus tard (ajouter colonne color etc..)
-    .addFields(
-      {
-        // TODO: Il faudrait que types prennent un S seulement si c'est au pluriel (plusieurs types)
-        name: 'Types',
-        value: fruit.types.length > 0 ? fruit.types.join(', ') : '—',
-        inline: true,
-      },
-      // TODO: Il faut styliser ça et ajouter des emojis
-      { name: 'HP', value: formatDfBonus(fruit.hpBonus), inline: true },
-      { name: 'Combat', value: formatDfBonus(fruit.combatBonus), inline: true },
-    );
-
-  if (fruit.imageUrl) {
-    embed.setThumbnail(buildAssetUrl(fruit.imageUrl));
-  }
-
-  return embed;
-}
-
-function formatDfBonus(value: number): string {
-  return value >= 0 ? `+${value}` : String(value);
 }

--- a/apps/bot/src/domains/resource/build-info-embed.ts
+++ b/apps/bot/src/domains/resource/build-info-embed.ts
@@ -1,0 +1,19 @@
+import type { ResourceTemplate } from '@one-piece/db';
+import type { EmbedBuilder } from 'discord.js';
+
+import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildAssetUrl } from '../../shared/build-asset-url.js';
+
+export function buildResourceInfoEmbed(template: ResourceTemplate): EmbedBuilder {
+  const embed = buildOpEmbed().setTitle(template.name);
+
+  if (template.description) {
+    embed.setDescription(template.description);
+  }
+
+  if (template.imageUrl) {
+    embed.setThumbnail(buildAssetUrl(template.imageUrl));
+  }
+
+  return embed;
+}

--- a/apps/bot/src/domains/resource/repository.ts
+++ b/apps/bot/src/domains/resource/repository.ts
@@ -1,5 +1,5 @@
-import { db, resourceInstance, resourceTemplate } from '@one-piece/db';
-import { asc, eq } from 'drizzle-orm';
+import { db, resourceInstance, resourceTemplate, type ResourceTemplate } from '@one-piece/db';
+import { asc, eq, ilike, or, sql } from 'drizzle-orm';
 
 import type { Inventory } from './types.js';
 
@@ -13,4 +13,18 @@ export async function getInventory(playerId: number): Promise<Inventory> {
     .innerJoin(resourceTemplate, eq(resourceInstance.templateId, resourceTemplate.id))
     .where(eq(resourceInstance.playerId, playerId))
     .orderBy(asc(resourceTemplate.name));
+}
+
+export async function searchManyByName(query: string): Promise<Array<ResourceTemplate>> {
+  return db
+    .select()
+    .from(resourceTemplate)
+    .where(or(sql`${resourceTemplate.name} % ${query}`, ilike(resourceTemplate.name, `%${query}%`)))
+    .orderBy(sql`similarity(${resourceTemplate.name}, ${query}) desc`)
+    .limit(25);
+}
+
+export async function findById(id: number): Promise<ResourceTemplate | undefined> {
+  const [row] = await db.select().from(resourceTemplate).where(eq(resourceTemplate.id, id)).limit(1);
+  return row;
 }

--- a/packages/db/drizzle/0013_redundant_switch.sql
+++ b/packages/db/drizzle/0013_redundant_switch.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "resource_template_name_trgm_idx" ON "resource_template" USING gin ("name" gin_trgm_ops);

--- a/packages/db/drizzle/meta/0013_snapshot.json
+++ b/packages/db/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,666 @@
+{
+  "id": "a520994d-21a8-42c3-8577-a6d17aae5f88",
+  "prevId": "daeb3e50-eeeb-4ea1-80fd-7cdd24686a93",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_template": {
+      "name": "character_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "combat": {
+          "name": "combat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_template_name_trgm_idx": {
+          "name": "character_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_template_name_unique": {
+          "name": "character_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_instance": {
+      "name": "devil_fruit_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_instance_player_template_uniq": {
+          "name": "devil_fruit_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devil_fruit_instance_template_id_devil_fruit_template_id_fk": {
+          "name": "devil_fruit_instance_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "devil_fruit_instance_player_id_player_id_fk": {
+          "name": "devil_fruit_instance_player_id_player_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_template": {
+      "name": "devil_fruit_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "devil_fruit_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::devil_fruit_type[]"
+        },
+        "hp_bonus": {
+          "name": "hp_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_bonus": {
+          "name": "combat_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_template_name_trgm_idx": {
+          "name": "devil_fruit_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devil_fruit_template_name_unique": {
+          "name": "devil_fruit_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player": {
+      "name": "player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "karma": {
+          "name": "karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounty": {
+          "name": "bounty",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_discord_id_unique": {
+          "name": "player_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_instance": {
+      "name": "resource_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_instance_player_template_uniq": {
+          "name": "resource_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_instance_template_id_resource_template_id_fk": {
+          "name": "resource_instance_template_id_resource_template_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "resource_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "resource_instance_player_id_player_id_fk": {
+          "name": "resource_instance_player_id_player_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_instance_quantity_non_negative": {
+          "name": "resource_instance_quantity_non_negative",
+          "value": "\"resource_instance\".\"quantity\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.resource_template": {
+      "name": "resource_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_template_name_trgm_idx": {
+          "name": "resource_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_template_name_unique": {
+          "name": "resource_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ship": {
+      "name": "ship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "hull_level": {
+          "name": "hull_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sail_level": {
+          "name": "sail_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "decks_level": {
+          "name": "decks_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cabins_level": {
+          "name": "cabins_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cargo_level": {
+          "name": "cargo_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ship_player_id_player_id_fk": {
+          "name": "ship_player_id_player_id_fk",
+          "tableFrom": "ship",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ship_player_id_unique": {
+          "name": "ship_player_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.devil_fruit_type": {
+      "name": "devil_fruit_type",
+      "schema": "public",
+      "values": [
+        "FEU",
+        "GLACE",
+        "MAGMA",
+        "FOUDRE",
+        "TENEBRES",
+        "LUMIERE",
+        "SABLE",
+        "GAZ",
+        "CAOUTCHOUC",
+        "POISON"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1777063119198,
       "tag": "0012_eager_slipstream",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1777132516554,
+      "tag": "0013_redundant_switch",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/domains/character/character_template/schema.ts
+++ b/packages/db/src/domains/character/character_template/schema.ts
@@ -15,3 +15,5 @@ export const characterTemplate = pgTable(
   },
   (table) => [index('character_template_name_trgm_idx').using('gin', sql`${table.name} gin_trgm_ops`)],
 );
+
+export type CharacterTemplate = typeof characterTemplate.$inferSelect;

--- a/packages/db/src/domains/character/index.ts
+++ b/packages/db/src/domains/character/index.ts
@@ -1,1 +1,1 @@
-export { characterTemplate } from './character_template/schema.js';
+export { characterTemplate, type CharacterTemplate } from './character_template/schema.js';

--- a/packages/db/src/domains/resource/resource_template/schema.ts
+++ b/packages/db/src/domains/resource/resource_template/schema.ts
@@ -1,14 +1,19 @@
-import { pgTable, text, varchar, serial } from 'drizzle-orm/pg-core';
+import { sql } from 'drizzle-orm';
+import { index, pgTable, serial, text, varchar } from 'drizzle-orm/pg-core';
 
 import { imageUrl, timestamps } from '../../../shared/helpers.js';
 
-export const resourceTemplate = pgTable('resource_template', {
-  id: serial('id').primaryKey(),
-  name: varchar('name', { length: 128 }).notNull().unique(),
-  ...imageUrl(),
-  description: text('description'),
-  ...timestamps(),
-});
+export const resourceTemplate = pgTable(
+  'resource_template',
+  {
+    id: serial('id').primaryKey(),
+    name: varchar('name', { length: 128 }).notNull().unique(),
+    ...imageUrl(),
+    description: text('description'),
+    ...timestamps(),
+  },
+  (table) => [index('resource_template_name_trgm_idx').using('gin', sql`${table.name} gin_trgm_ops`)],
+);
 
 export type ResourceTemplateInsert = typeof resourceTemplate.$inferInsert;
 export type ResourceTemplate = typeof resourceTemplate.$inferSelect;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -2,5 +2,6 @@ export { closeDb, db, type Db } from './client.js';
 export * from './schema.js';
 export { type Player } from './domains/player/index.js';
 export { type DevilFruitTemplate } from './domains/devil_fruit/index.js';
+export { type CharacterTemplate } from './domains/character/index.js';
 export { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type Ship, type ShipModuleKey } from './domains/ship/index.js';
 export { type ResourceName, type ResourceTemplate } from './domains/resource/index.js';


### PR DESCRIPTION
On pose les bases pour l'architecture du !info 
- On créer les fonctions pour récupérer la données des character template et resource template via le nom
- On ajoute un index trigram sur ceux qui en ont pas (permet de faire des recherches approximatifs (Lufy => Luffy)
- On uniforme tout en "buildXinfoembed" aulieu de ui.ts