### PR TITLE
refactor(bot): add discord utils barrel

### DIFF
--- a/apps/bot/src/discord/interactionRouter.ts
+++ b/apps/bot/src/discord/interactionRouter.ts
@@ -11,7 +11,7 @@ import { buildRegistryWithUniqueNames } from '../shared/build-registry.js';
 import { CUSTOM_ID_SEPARATOR } from './constants.js';
 import { AppError, ValidationError } from './errors.js';
 import type { ButtonHandler } from './types.js';
-import { buildOpEmbed } from './utils/build-op-embed.js';
+import { buildOpEmbed } from './utils/index.js';
 
 const allButtonHandlers: Array<ButtonHandler> = [
   ...infoButtonHandlers,

--- a/apps/bot/src/discord/router.ts
+++ b/apps/bot/src/discord/router.ts
@@ -10,7 +10,7 @@ import { shipCommands } from '../domains/ship/commands/index.js';
 import { buildRegistryWithUniqueNames } from '../shared/build-registry.js';
 
 import { AppError } from './errors.js';
-import { buildOpEmbed } from './utils/build-op-embed.js';
+import { buildOpEmbed } from './utils/index.js';
 
 const allCommands = [
   ...playerCommands,

--- a/apps/bot/src/discord/utils/index.ts
+++ b/apps/bot/src/discord/utils/index.ts
@@ -1,0 +1,7 @@
+export * from './build-custom-id.js';
+export * from './build-menu-buttons.js';
+export * from './build-op-embed.js';
+export * from './build-pagination-buttons.js';
+export * from './get-target-user.js';
+export * from './paginate.js';
+export * from './parse-integer-arg.js';

--- a/apps/bot/src/domains/_dev/commands/color.ts
+++ b/apps/bot/src/domains/_dev/commands/color.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../../discord/utils/index.js';
 
 function getRandomColor(): number {
   return Math.floor(Math.random() * 0xffffff);

--- a/apps/bot/src/domains/_dev/commands/debug/df.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/df.ts
@@ -1,6 +1,6 @@
 import { NotFoundError } from '../../../../discord/errors.js';
 import type { Command } from '../../../../discord/types.js';
-import { parseIntegerArg } from '../../../../discord/utils/parse-integer-arg.js';
+import { parseIntegerArg } from '../../../../discord/utils/index.js';
 import * as devilFruitRepository from '../../../devil_fruit/repository.js';
 
 import { replyDebugData } from './utils.js';

--- a/apps/bot/src/domains/_dev/commands/debug/player.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/player.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../../discord/types.js';
-import { getTargetUser } from '../../../../discord/utils/get-target-user.js';
+import { getTargetUser } from '../../../../discord/utils/index.js';
 import { findOrCreatePlayer } from '../../../player/service.js';
 
 import { replyDebugData } from './utils.js';

--- a/apps/bot/src/domains/_dev/commands/debug/resource.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/resource.ts
@@ -1,6 +1,6 @@
 import { NotFoundError } from '../../../../discord/errors.js';
 import type { Command } from '../../../../discord/types.js';
-import { parseIntegerArg } from '../../../../discord/utils/parse-integer-arg.js';
+import { parseIntegerArg } from '../../../../discord/utils/index.js';
 import * as resourceRepository from '../../../resource/repository.js';
 
 import { replyDebugData } from './utils.js';

--- a/apps/bot/src/domains/_dev/commands/debug/ship.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/ship.ts
@@ -1,6 +1,6 @@
 import { NotFoundError } from '../../../../discord/errors.js';
 import type { Command } from '../../../../discord/types.js';
-import { getTargetUser } from '../../../../discord/utils/get-target-user.js';
+import { getTargetUser } from '../../../../discord/utils/index.js';
 import { findOrCreatePlayer } from '../../../player/service.js';
 import * as shipRepository from '../../../ship/repository.js';
 

--- a/apps/bot/src/domains/_dev/commands/embed.ts
+++ b/apps/bot/src/domains/_dev/commands/embed.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../../discord/utils/index.js';
 
 export const embedCommand: Command = {
   name: 'embed',

--- a/apps/bot/src/domains/_dev/commands/emoji.ts
+++ b/apps/bot/src/domains/_dev/commands/emoji.ts
@@ -2,8 +2,7 @@ import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 import sampleSize from 'lodash/sampleSize.js';
 
 import type { Command } from '../../../discord/types.js';
-import { buildCustomId } from '../../../discord/utils/build-custom-id.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
+import { buildCustomId, buildOpEmbed } from '../../../discord/utils/index.js';
 const EMOJIS: Array<string> = ['🍖', '🏴‍☠️', '⚓', '🐉', '🗺️', '🛶', '☠️', '🍈', '🦈', '🐟', '🏝️', '⚔️', '🔫', '🔪'];
 
 export const emojiCommand: Command = {

--- a/apps/bot/src/domains/_dev/commands/moi.ts
+++ b/apps/bot/src/domains/_dev/commands/moi.ts
@@ -1,6 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
-import { getTargetUser } from '../../../discord/utils/get-target-user.js';
+import { buildOpEmbed, getTargetUser } from '../../../discord/utils/index.js';
 
 // TODO: supprimer avant la prod
 export const moiCommand: Command = {

--- a/apps/bot/src/domains/_dev/commands/randomcat.ts
+++ b/apps/bot/src/domains/_dev/commands/randomcat.ts
@@ -1,7 +1,7 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../../discord/utils/index.js';
 
 const catImages = ['https://i.imgur.com/xJ4oIrC.jpeg', 'https://i.imgur.com/g2BEPjU.jpeg', 'https://i.imgur.com/c7FhEn6.png'];
 

--- a/apps/bot/src/domains/_dev/interactions/randomcat-button.ts
+++ b/apps/bot/src/domains/_dev/interactions/randomcat-button.ts
@@ -1,7 +1,7 @@
 import type { ButtonInteraction } from 'discord.js';
 
 import type { ButtonHandler } from '../../../discord/types.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../../discord/utils/index.js';
 
 export const randomCatButtonHandler: ButtonHandler = {
   name: 'cat',

--- a/apps/bot/src/domains/_info/commands/info.ts
+++ b/apps/bot/src/domains/_info/commands/info.ts
@@ -2,8 +2,7 @@ import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
 
 import { DISCORD_ACTION_ROW_MAX_BUTTONS, DISCORD_BUTTON_LABEL_MAX_LENGTH } from '../../../discord/constants.js';
 import type { Command } from '../../../discord/types.js';
-import { buildCustomId } from '../../../discord/utils/build-custom-id.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
+import { buildCustomId, buildOpEmbed } from '../../../discord/utils/index.js';
 import { DOMAIN_EMOJI } from '../../../shared/domains.js';
 import { truncate } from '../../../shared/utils.js';
 import { INFO_BUTTON_NAME } from '../interactions/info-button.js';

--- a/apps/bot/src/domains/_info/interactions/info-button.ts
+++ b/apps/bot/src/domains/_info/interactions/info-button.ts
@@ -1,6 +1,6 @@
 import { ValidationError } from '../../../discord/errors.js';
 import type { ButtonHandler } from '../../../discord/types.js';
-import { parseIntegerArg } from '../../../discord/utils/parse-integer-arg.js';
+import { parseIntegerArg } from '../../../discord/utils/index.js';
 import type { DomainName } from '../../../shared/domains.js';
 import { infoProviderByDomain } from '../registry.js';
 

--- a/apps/bot/src/domains/character/build-info-embed.ts
+++ b/apps/bot/src/domains/character/build-info-embed.ts
@@ -1,7 +1,7 @@
 import type { CharacterTemplate } from '@one-piece/db';
 import type { EmbedBuilder } from 'discord.js';
 
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../discord/utils/index.js';
 import { buildAssetUrl } from '../../shared/build-asset-url.js';
 import { DOMAIN_EMOJI, DOMAIN_LABEL } from '../../shared/domains.js';
 

--- a/apps/bot/src/domains/character/characters-nav-button.ts
+++ b/apps/bot/src/domains/character/characters-nav-button.ts
@@ -1,6 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from 'discord.js';
 
-import { buildCustomId } from '../../discord/utils/build-custom-id.js';
+import { buildCustomId } from '../../discord/utils/index.js';
 import { DOMAIN_EMOJI } from '../../shared/domains.js';
 
 import { CHARACTERS_BUTTON_NAME } from './constants.js';

--- a/apps/bot/src/domains/character/characters-view.ts
+++ b/apps/bot/src/domains/character/characters-view.ts
@@ -1,10 +1,7 @@
 import type { Player, Ship } from '@one-piece/db';
 
 import type { View } from '../../discord/types.js';
-import { buildMenuButtons } from '../../discord/utils/build-menu-buttons.js';
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
-import { buildPaginationButtons } from '../../discord/utils/build-pagination-buttons.js';
-import { clampPage, splitIntoPages } from '../../discord/utils/paginate.js';
+import { buildMenuButtons, buildOpEmbed, buildPaginationButtons, clampPage, splitIntoPages } from '../../discord/utils/index.js';
 import { getCrewCapacity } from '../crew/capacity.js';
 
 import { CHARACTERS_BUTTON_NAME } from './constants.js';

--- a/apps/bot/src/domains/character/commands/crew.ts
+++ b/apps/bot/src/domains/character/commands/crew.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { getTargetUser } from '../../../discord/utils/get-target-user.js';
+import { getTargetUser } from '../../../discord/utils/index.js';
 import { findOrCreatePlayer } from '../../player/service.js';
 import * as shipRepository from '../../ship/repository.js';
 import { buildCharactersView } from '../characters-view.js';

--- a/apps/bot/src/domains/character/interactions/characters-pagination.ts
+++ b/apps/bot/src/domains/character/interactions/characters-pagination.ts
@@ -1,7 +1,7 @@
 import type { ButtonInteraction } from 'discord.js';
 
 import type { ButtonHandler } from '../../../discord/types.js';
-import { parseIntegerArg } from '../../../discord/utils/parse-integer-arg.js';
+import { parseIntegerArg } from '../../../discord/utils/index.js';
 import * as playerRepository from '../../player/repository.js';
 import * as shipRepository from '../../ship/repository.js';
 import { buildCharactersView } from '../characters-view.js';

--- a/apps/bot/src/domains/devil_fruit/build-info-embed.ts
+++ b/apps/bot/src/domains/devil_fruit/build-info-embed.ts
@@ -1,7 +1,7 @@
 import type { DevilFruitTemplate } from '@one-piece/db';
 import type { EmbedBuilder } from 'discord.js';
 
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../discord/utils/index.js';
 import { buildAssetUrl } from '../../shared/build-asset-url.js';
 import { DOMAIN_EMOJI, DOMAIN_LABEL } from '../../shared/domains.js';
 

--- a/apps/bot/src/domains/fishing/commands/fishing.ts
+++ b/apps/bot/src/domains/fishing/commands/fishing.ts
@@ -1,6 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
-import { getTargetUser } from '../../../discord/utils/get-target-user.js';
+import { buildOpEmbed, getTargetUser } from '../../../discord/utils/index.js';
 import { findOrCreatePlayer } from '../../player/service.js';
 import { runFishingAttempt } from '../service.js';
 

--- a/apps/bot/src/domains/player/commands/profil.ts
+++ b/apps/bot/src/domains/player/commands/profil.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { getTargetUser } from '../../../discord/utils/get-target-user.js';
+import { getTargetUser } from '../../../discord/utils/index.js';
 import { buildProfilView } from '../profil-view.js';
 import { findOrCreatePlayer } from '../service.js';
 

--- a/apps/bot/src/domains/player/interactions/profil-button.ts
+++ b/apps/bot/src/domains/player/interactions/profil-button.ts
@@ -1,7 +1,7 @@
 import type { ButtonInteraction } from 'discord.js';
 
 import type { ButtonHandler } from '../../../discord/types.js';
-import { parseIntegerArg } from '../../../discord/utils/parse-integer-arg.js';
+import { parseIntegerArg } from '../../../discord/utils/index.js';
 import { PROFIL_BUTTON_NAME } from '../constants.js';
 import { buildProfilView } from '../profil-view.js';
 

--- a/apps/bot/src/domains/player/profil-button.ts
+++ b/apps/bot/src/domains/player/profil-button.ts
@@ -1,6 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from 'discord.js';
 
-import { buildCustomId } from '../../discord/utils/build-custom-id.js';
+import { buildCustomId } from '../../discord/utils/index.js';
 
 import { PROFIL_BUTTON_NAME } from './constants.js';
 

--- a/apps/bot/src/domains/player/profil-view.ts
+++ b/apps/bot/src/domains/player/profil-view.ts
@@ -1,6 +1,5 @@
 import type { View } from '../../discord/types.js';
-import { buildMenuButtons } from '../../discord/utils/build-menu-buttons.js';
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildMenuButtons, buildOpEmbed } from '../../discord/utils/index.js';
 import { formatBerry } from '../economy/utils/format-berry.js';
 
 import { PROFIL_BUTTON_NAME } from './constants.js';

--- a/apps/bot/src/domains/resource/build-info-embed.ts
+++ b/apps/bot/src/domains/resource/build-info-embed.ts
@@ -1,7 +1,7 @@
 import type { ResourceTemplate } from '@one-piece/db';
 import type { EmbedBuilder } from 'discord.js';
 
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../discord/utils/index.js';
 import { buildAssetUrl } from '../../shared/build-asset-url.js';
 import { DOMAIN_EMOJI, DOMAIN_LABEL } from '../../shared/domains.js';
 

--- a/apps/bot/src/domains/resource/commands/inventaire.ts
+++ b/apps/bot/src/domains/resource/commands/inventaire.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { getTargetUser } from '../../../discord/utils/get-target-user.js';
+import { getTargetUser } from '../../../discord/utils/index.js';
 import { findOrCreatePlayer } from '../../player/service.js';
 import { buildInventoryView } from '../inventory-view.js';
 import { getInventory } from '../repository.js';

--- a/apps/bot/src/domains/resource/interactions/inventory-pagination.ts
+++ b/apps/bot/src/domains/resource/interactions/inventory-pagination.ts
@@ -1,7 +1,7 @@
 import type { ButtonInteraction } from 'discord.js';
 
 import type { ButtonHandler } from '../../../discord/types.js';
-import { parseIntegerArg } from '../../../discord/utils/parse-integer-arg.js';
+import { parseIntegerArg } from '../../../discord/utils/index.js';
 import * as playerRepository from '../../player/repository.js';
 import { INVENTORY_BUTTON_NAME } from '../constants.js';
 import { buildInventoryView } from '../inventory-view.js';

--- a/apps/bot/src/domains/resource/inventory-nav-button.ts
+++ b/apps/bot/src/domains/resource/inventory-nav-button.ts
@@ -1,6 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from 'discord.js';
 
-import { buildCustomId } from '../../discord/utils/build-custom-id.js';
+import { buildCustomId } from '../../discord/utils/index.js';
 
 import { INVENTORY_BUTTON_NAME } from './constants.js';
 

--- a/apps/bot/src/domains/resource/inventory-view.ts
+++ b/apps/bot/src/domains/resource/inventory-view.ts
@@ -1,10 +1,7 @@
 import type { Player } from '@one-piece/db';
 
 import type { View } from '../../discord/types.js';
-import { buildMenuButtons } from '../../discord/utils/build-menu-buttons.js';
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
-import { buildPaginationButtons } from '../../discord/utils/build-pagination-buttons.js';
-import { clampPage, splitIntoPages } from '../../discord/utils/paginate.js';
+import { buildMenuButtons, buildOpEmbed, buildPaginationButtons, clampPage, splitIntoPages } from '../../discord/utils/index.js';
 
 import { INVENTORY_BUTTON_NAME } from './constants.js';
 import type { Inventory } from './types.js';

--- a/apps/bot/src/domains/ship/commands/rename.ts
+++ b/apps/bot/src/domains/ship/commands/rename.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed } from '../../../discord/utils/build-op-embed.js';
+import { buildOpEmbed } from '../../../discord/utils/index.js';
 import { findOrCreatePlayer } from '../../player/service.js';
 import { ShipNameValidationError } from '../service.js';
 import { renameShip } from '../service.js';

--- a/apps/bot/src/domains/ship/commands/ship.ts
+++ b/apps/bot/src/domains/ship/commands/ship.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../../../discord/types.js';
-import { getTargetUser } from '../../../discord/utils/get-target-user.js';
+import { getTargetUser } from '../../../discord/utils/index.js';
 import { findOrCreatePlayer } from '../../player/service.js';
 import { buildShipView } from '../ship-view.js';
 

--- a/apps/bot/src/domains/ship/interactions/ship-button.ts
+++ b/apps/bot/src/domains/ship/interactions/ship-button.ts
@@ -1,7 +1,7 @@
 import type { ButtonInteraction } from 'discord.js';
 
 import type { ButtonHandler } from '../../../discord/types.js';
-import { parseIntegerArg } from '../../../discord/utils/parse-integer-arg.js';
+import { parseIntegerArg } from '../../../discord/utils/index.js';
 import { SHIP_BUTTON_NAME } from '../constants.js';
 import { buildShipView } from '../ship-view.js';
 

--- a/apps/bot/src/domains/ship/ship-button.ts
+++ b/apps/bot/src/domains/ship/ship-button.ts
@@ -1,6 +1,6 @@
 import { ButtonBuilder, ButtonStyle } from 'discord.js';
 
-import { buildCustomId } from '../../discord/utils/build-custom-id.js';
+import { buildCustomId } from '../../discord/utils/index.js';
 
 import { SHIP_BUTTON_NAME } from './constants.js';
 

--- a/apps/bot/src/domains/ship/ship-view.ts
+++ b/apps/bot/src/domains/ship/ship-view.ts
@@ -1,8 +1,7 @@
 import { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type ShipModuleKey } from '@one-piece/db';
 
 import type { View } from '../../discord/types.js';
-import { buildMenuButtons } from '../../discord/utils/build-menu-buttons.js';
-import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+import { buildMenuButtons, buildOpEmbed } from '../../discord/utils/index.js';
 
 import { SHIP_BUTTON_NAME } from './constants.js';
 import { SHIP_MODULES } from './modules.js';


### PR DESCRIPTION
## Résumé

[#114](https://github.com/toutpourlamif/discord-bot-one-piece/issues/114)

- Ajoute un barrel export dans `apps/bot/src/discord/utils/index.ts`
- Migre les imports `discord/utils/*` vers `discord/utils/index.js`
- Regroupe les imports multiples sur une seule ligne quand possible
- Exporte aussi `buildPaginationButtons` et `parseIntegerArg`, déjà présents dans le dossier `utils`