### PR TITLE
refactor(bot): support command aliases

### DIFF
--- a/apps/bot/src/discord/interactionRouter.ts
+++ b/apps/bot/src/discord/interactionRouter.ts
@@ -6,7 +6,7 @@ import { characterButtonHandlers } from '../domains/character/interactions/index
 import { playerButtonHandlers } from '../domains/player/index.js';
 import { resourceButtonHandlers } from '../domains/resource/index.js';
 import { shipButtonHandlers } from '../domains/ship/index.js';
-import { buildRegistryWithUniqueNames } from '../shared/build-registry.js';
+import { buildRegistry } from '../shared/build-registry.js';
 
 import { CUSTOM_ID_SEPARATOR } from './constants.js';
 import { AppError, ValidationError } from './errors.js';
@@ -21,7 +21,7 @@ const allButtonHandlers: Array<ButtonHandler> = [
   ...characterButtonHandlers,
   ...devButtonHandlers,
 ];
-const buttonRegistry = buildRegistryWithUniqueNames(allButtonHandlers, (h) => h.name);
+const buttonRegistry = buildRegistry(allButtonHandlers, (h) => h.name);
 
 /** Dispatche une interaction vers le bon handler. Voir `docs/discord.md`. */
 export async function routeInteraction(interaction: Interaction): Promise<void> {

--- a/apps/bot/src/discord/router.ts
+++ b/apps/bot/src/discord/router.ts
@@ -7,9 +7,9 @@ import { fishingCommands } from '../domains/fishing/index.js';
 import { playerCommands } from '../domains/player/index.js';
 import { resourceCommands } from '../domains/resource/index.js';
 import { shipCommands } from '../domains/ship/commands/index.js';
-import { buildRegistryWithUniqueNames } from '../shared/build-registry.js';
 
 import { AppError } from './errors.js';
+import type { Command } from './types.js';
 import { buildOpEmbed } from './utils/index.js';
 
 const allCommands = [
@@ -21,7 +21,23 @@ const allCommands = [
   ...fishingCommands,
   ...characterCommands,
 ];
-const registry = buildRegistryWithUniqueNames(allCommands, (c) => c.name.toLowerCase());
+const registry = new Map<string, Command>();
+
+for (const command of allCommands) {
+  for (const name of getCommandNames(command)) {
+    const key = name.toLowerCase();
+
+    if (registry.has(key)) {
+      throw new Error(`Doublon dans le registre: "${key}"`);
+    }
+
+    registry.set(key, command);
+  }
+}
+
+function getCommandNames(command: Command): Array<string> {
+  return Array.isArray(command.name) ? command.name : [command.name];
+}
 
 /** Dispatche un message vers le bon handler de commande. Voir `docs/discord.md`. */
 export async function routeMessage(message: Message, prefix: string): Promise<void> {

--- a/apps/bot/src/discord/router.ts
+++ b/apps/bot/src/discord/router.ts
@@ -7,9 +7,9 @@ import { fishingCommands } from '../domains/fishing/index.js';
 import { playerCommands } from '../domains/player/index.js';
 import { resourceCommands } from '../domains/resource/index.js';
 import { shipCommands } from '../domains/ship/commands/index.js';
+import { buildRegistry } from '../shared/build-registry.js';
 
 import { AppError } from './errors.js';
-import type { Command } from './types.js';
 import { buildOpEmbed } from './utils/index.js';
 
 const allCommands = [
@@ -21,23 +21,9 @@ const allCommands = [
   ...fishingCommands,
   ...characterCommands,
 ];
-const registry = new Map<string, Command>();
-
-for (const command of allCommands) {
-  for (const name of getCommandNames(command)) {
-    const key = name.toLowerCase();
-
-    if (registry.has(key)) {
-      throw new Error(`Doublon dans le registre: "${key}"`);
-    }
-
-    registry.set(key, command);
-  }
-}
-
-function getCommandNames(command: Command): Array<string> {
-  return Array.isArray(command.name) ? command.name : [command.name];
-}
+const registry = buildRegistry(allCommands, (command) =>
+  Array.isArray(command.name) ? command.name.map((name) => name.toLowerCase()) : command.name.toLowerCase(),
+);
 
 /** Dispatche un message vers le bon handler de commande. Voir `docs/discord.md`. */
 export async function routeMessage(message: Message, prefix: string): Promise<void> {

--- a/apps/bot/src/discord/types.ts
+++ b/apps/bot/src/discord/types.ts
@@ -1,7 +1,9 @@
 import type { ActionRowBuilder, ButtonBuilder, ButtonInteraction, EmbedBuilder, Message } from 'discord.js';
 
+export type CommandName = string | Array<string>;
+
 export type Command = {
-  name: string;
+  name: CommandName;
   handler: (message: Message, args: Array<string>) => Promise<void>;
 };
 

--- a/apps/bot/src/domains/fishing/commands/fishing.ts
+++ b/apps/bot/src/domains/fishing/commands/fishing.ts
@@ -4,9 +4,7 @@ import { findOrCreatePlayer } from '../../player/service.js';
 import { runFishingAttempt } from '../service.js';
 
 export const fishingCommand: Command = {
-  // TODO: !fish devrait marcher aussi, il faut retravailler l'architecture pour que name soit une liste de strings
-  // https://github.com/toutpourlamif/discord-bot-one-piece/issues/118
-  name: 'fish',
+  name: ['fishing', 'fish'],
   async handler(message) {
     const user = getTargetUser(message);
     const { player } = await findOrCreatePlayer(user.id, user.username);

--- a/apps/bot/src/shared/build-registry.ts
+++ b/apps/bot/src/shared/build-registry.ts
@@ -1,12 +1,18 @@
 /** Construit une `Map<name, item>` depuis un tableau, en throwant si deux items partagent la même clé `name`. */
-export function buildRegistryWithUniqueNames<T>(items: Array<T>, getName: (item: T) => string): Map<string, T> {
+export function buildRegistry<T>(items: Array<T>, getNames: (item: T) => string | Array<string>): Map<string, T> {
   const registry = new Map<string, T>();
+
   for (const item of items) {
-    const name = getName(item);
-    if (registry.has(name)) {
-      throw new Error(`Doublon dans le registre: "${name}"`);
+    const names = getNames(item);
+
+    for (const name of Array.isArray(names) ? names : [names]) {
+      if (registry.has(name)) {
+        throw new Error(`Doublon dans le registre: "${name}"`);
+      }
+
+      registry.set(name, item);
     }
-    registry.set(name, item);
   }
+
   return registry;
 }


### PR DESCRIPTION
## Résumé

#118 

- Permet à une commande de déclarer plusieurs noms avec `name: string | string[]`
- Enregistre chaque alias dans le router avec détection des doublons
- Ajoute les alias `!fishing` et `!fish` sur la commande pêche
- Supprime le TODO lié aux alias dans `fishing.ts`


## Test manuel

- `!fish`
- `!fishing`
