### PR TITLE
160 feature table log pour logger les événements du jeu

### DIFF
--- a/apps/bot/src/domains/crew/repository.ts
+++ b/apps/bot/src/domains/crew/repository.ts
@@ -6,11 +6,14 @@ export async function findCharacterInstanceById(instanceId: number): Promise<Cha
   return row;
 }
 
-export async function removeCaptain(playerId: number, client: DbOrTransaction): Promise<void> {
-  await client
+export async function removeCaptain(playerId: number, client: DbOrTransaction): Promise<number | null> {
+  const [previous] = await client
     .update(characterInstance)
     .set({ isCaptain: false })
-    .where(and(eq(characterInstance.playerId, playerId), eq(characterInstance.isCaptain, true)));
+    .where(and(eq(characterInstance.playerId, playerId), eq(characterInstance.isCaptain, true)))
+    .returning({ id: characterInstance.id });
+
+  return previous?.id ?? null;
 }
 
 export async function setCaptain(playerId: number, instanceId: number, client: DbOrTransaction): Promise<boolean> {

--- a/apps/bot/src/domains/crew/repository.ts
+++ b/apps/bot/src/domains/crew/repository.ts
@@ -1,19 +1,22 @@
 import { characterInstance, db, type CharacterInstance, type DbOrTransaction } from '@one-piece/db';
 import { and, eq, isNotNull } from 'drizzle-orm';
 
+import { InternalError } from '../../discord/errors.js';
+
 export async function findCharacterInstanceById(instanceId: number): Promise<CharacterInstance | undefined> {
   const [row] = await db.select().from(characterInstance).where(eq(characterInstance.id, instanceId)).limit(1);
   return row;
 }
 
-export async function removeCaptain(playerId: number, client: DbOrTransaction): Promise<number | null> {
+export async function removeCaptain(playerId: number, client: DbOrTransaction): Promise<number> {
   const [previous] = await client
     .update(characterInstance)
     .set({ isCaptain: false })
     .where(and(eq(characterInstance.playerId, playerId), eq(characterInstance.isCaptain, true)))
     .returning({ id: characterInstance.id });
 
-  return previous?.id ?? null;
+  if (!previous) throw new InternalError(`Le joueur ${playerId} n'a pas de capitaine actuel.`);
+  return previous.id;
 }
 
 export async function setCaptain(playerId: number, instanceId: number, client: DbOrTransaction): Promise<boolean> {

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -35,7 +35,6 @@ export async function replaceCaptainOfPlayer(playerId: number, instanceId: numbe
       },
       actorPlayerId: playerId,
       target: { type: 'character_instance', id: instanceId },
-      source: 'discord_button',
       client: transaction,
     });
   });

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -3,7 +3,7 @@ import { db } from '@one-piece/db';
 import { NotFoundError } from '../../discord/errors.js';
 import * as characterRepository from '../character/repository.js';
 import type { CharacterRow } from '../character/types.js';
-import { appendHistory } from '../history/index.js';
+import * as historyRepository from '../history/index.js';
 
 import * as crewRepository from './repository.js';
 
@@ -27,7 +27,7 @@ export async function replaceCaptainOfPlayer(playerId: number, instanceId: numbe
       throw new NotFoundError("Ce personnage n'est pas dans ton équipage.");
     }
 
-    await appendHistory({
+    await historyRepository.appendHistory({
       type: 'crew.captain_changed',
       payload: {
         fromCharacterInstanceId: previousCaptainId,

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -3,6 +3,7 @@ import { db } from '@one-piece/db';
 import { NotFoundError } from '../../discord/errors.js';
 import * as characterRepository from '../character/repository.js';
 import type { CharacterRow } from '../character/types.js';
+import { appendHistory } from '../history/index.js';
 
 import * as crewRepository from './repository.js';
 
@@ -19,11 +20,23 @@ export async function getCrewByPlayerId(playerId: number): Promise<Array<Charact
 
 export async function replaceCaptainOfPlayer(playerId: number, instanceId: number): Promise<void> {
   await db.transaction(async (transaction) => {
-    await crewRepository.removeCaptain(playerId, transaction);
+    const previousCaptainId = await crewRepository.removeCaptain(playerId, transaction);
 
     const captainReplaced = await crewRepository.setCaptain(playerId, instanceId, transaction);
     if (!captainReplaced) {
       throw new NotFoundError("Ce personnage n'est pas dans ton équipage.");
     }
+
+    await appendHistory({
+      type: 'crew.captain_changed',
+      payload: {
+        fromCharacterInstanceId: previousCaptainId,
+        toCharacterInstanceId: instanceId,
+      },
+      actorPlayerId: playerId,
+      target: { type: 'character_instance', id: instanceId },
+      source: 'discord_button',
+      client: transaction,
+    });
   });
 }

--- a/apps/bot/src/domains/history/index.ts
+++ b/apps/bot/src/domains/history/index.ts
@@ -1,0 +1,1 @@
+export { appendHistory } from './repository.js';

--- a/apps/bot/src/domains/history/repository.ts
+++ b/apps/bot/src/domains/history/repository.ts
@@ -1,0 +1,22 @@
+import { db, history, type DbOrTransaction } from '@one-piece/db';
+
+import type { HistorySource, HistoryTarget } from './types/common.js';
+import type { Log } from './types/index.js';
+
+type AppendHistoryArgs = Log & {
+  actorPlayerId?: number;
+  target?: HistoryTarget;
+  source?: HistorySource;
+  client?: DbOrTransaction;
+};
+
+export async function appendHistory({ type, payload, actorPlayerId, target, source, client = db }: AppendHistoryArgs): Promise<void> {
+  await client.insert(history).values({
+    eventType: type,
+    actorPlayerId,
+    targetType: target?.type,
+    targetId: target?.id,
+    payload,
+    source,
+  });
+}

--- a/apps/bot/src/domains/history/repository.ts
+++ b/apps/bot/src/domains/history/repository.ts
@@ -1,22 +1,20 @@
 import { db, history, type DbOrTransaction } from '@one-piece/db';
 
-import type { HistorySource, HistoryTarget } from './types/common.js';
+import type { HistoryTarget } from './types/common.js';
 import type { Log } from './types/index.js';
 
 type AppendHistoryArgs = Log & {
   actorPlayerId?: number;
   target?: HistoryTarget;
-  source?: HistorySource;
   client?: DbOrTransaction;
 };
 
-export async function appendHistory({ type, payload, actorPlayerId, target, source, client = db }: AppendHistoryArgs): Promise<void> {
+export async function appendHistory({ type, payload, actorPlayerId, target, client = db }: AppendHistoryArgs): Promise<void> {
   await client.insert(history).values({
     eventType: type,
     actorPlayerId,
     targetType: target?.type,
     targetId: target?.id,
     payload,
-    source,
   });
 }

--- a/apps/bot/src/domains/history/types/common.ts
+++ b/apps/bot/src/domains/history/types/common.ts
@@ -1,0 +1,13 @@
+export type HistoryTargetType =
+  | 'character_instance'
+  | 'character_template'
+  | 'devil_fruit_instance'
+  | 'devil_fruit_template'
+  | 'player'
+  | 'resource_instance'
+  | 'resource_template'
+  | 'ship';
+
+export type HistoryTarget = { type: HistoryTargetType; id: number };
+
+export type HistorySource = 'discord_button' | 'discord_command' | 'cron' | 'admin';

--- a/apps/bot/src/domains/history/types/common.ts
+++ b/apps/bot/src/domains/history/types/common.ts
@@ -9,5 +9,3 @@ export type HistoryTargetType =
   | 'ship';
 
 export type HistoryTarget = { type: HistoryTargetType; id: number };
-
-export type HistorySource = 'discord_button' | 'discord_command' | 'cron' | 'admin';

--- a/apps/bot/src/domains/history/types/crew.ts
+++ b/apps/bot/src/domains/history/types/crew.ts
@@ -1,0 +1,9 @@
+export type CaptainChangedLog = {
+  type: 'crew.captain_changed';
+  payload: {
+    fromCharacterInstanceId: number | null;
+    toCharacterInstanceId: number;
+  };
+};
+
+export type CrewLog = CaptainChangedLog;

--- a/apps/bot/src/domains/history/types/crew.ts
+++ b/apps/bot/src/domains/history/types/crew.ts
@@ -1,7 +1,7 @@
 export type CaptainChangedLog = {
   type: 'crew.captain_changed';
   payload: {
-    fromCharacterInstanceId: number | null;
+    fromCharacterInstanceId: number;
     toCharacterInstanceId: number;
   };
 };

--- a/apps/bot/src/domains/history/types/index.ts
+++ b/apps/bot/src/domains/history/types/index.ts
@@ -1,0 +1,3 @@
+import type { CrewLog } from './crew.js';
+
+export type Log = CrewLog;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,7 @@ On ouvre un domaine (dossier + doc) uniquement au moment où on commence à code
 | `economy`     | Berry, shops, marchands                                                                                                            |
 | `resource`    | Matériaux de craft, artefacts de main story, FDD non consommés                                                                     |
 | `fishing`     | Action `/pêcher` à la demande : loot, events, avancée scénario                                                                     |
+| `history`     | HISTORIQUE DE tout ce qu'il se passe et qui peut servir plus tard pour analyser / pour des events                                  |
 
 D'autres domaines viendront s'ajouter quand le besoin apparaîtra (combat, world…). On ne les crée pas en amont.
 

--- a/docs/domains/history.md
+++ b/docs/domains/history.md
@@ -1,0 +1,106 @@
+# Domaine : history
+
+## Concept
+
+L'**historique** est la mémoire du bot. À chaque fois qu'un joueur fait quelque chose qu'on voudra peut-être ressortir plus tard, on l'écrit ici. Une ligne = une action passée.
+
+## À quoi ça sert
+
+Deux usages, dans cet ordre d'importance :
+
+1. **Réutiliser le passé pour les events.** Beaucoup d'events réagissent à ce que le joueur a fait avant. Exemples :
+   - Un joueur refuse 4 fois la même île → il tourne en rond, ses personnages ont la nausée.
+   - Un joueur a déjà mangé un fruit du démon → on lui en propose moins pendant un certain temps.
+   - Un joueur a trahi son capitaine → certains personnages refusent de rejoindre son équipage.
+
+   Sans l'historique, ces infos sont perdues une fois l'action faite. La table joueur ne peut pas tout porter sous forme de compteurs ad hoc.
+
+2. **Comprendre ce qui se passe dans le bot.** Combien de joueurs utilisent telle action, quelle action est la plus populaire, à quel moment les joueurs décrochent, debug d'incidents joueur (« il dit qu'il a perdu son fruit, qu'est-ce qui s'est passé ? »).
+
+## Règle de base : on n'écrase jamais une ligne
+
+Une fois écrite, une entrée ne change plus. Si une action est annulée, on écrit une **nouvelle** entrée (`xxx.cancelled`) plutôt que de modifier l'ancienne. Comme ça l'historique reste fidèle à ce qui s'est vraiment passé.
+
+## Ce qu'on écrit (ou pas)
+
+On écrit dès qu'une action peut être **comptée, recoupée ou rappelée plus tard**.
+
+On n'écrit **pas** ce qui est déjà déductible de l'état actuel. Exemple : pas besoin d'enregistrer la création du joueur, on a déjà `player.created_at`.
+
+## Comment c'est organisé
+
+### La table `history`
+
+Une seule table, avec quelques colonnes fixes pour les questions qu'on posera souvent (qui, quand, quoi, sur quoi) et un champ `payload` libre en JSON pour les détails spécifiques à chaque type d'action.
+
+| Colonne                     | À quoi ça sert                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------ |
+| `occurred_at`               | Quand l'action a eu lieu                                                             |
+| `event_type`                | Quoi : `crew.captain_changed`, `island.refused`, `fruit.eaten`…                      |
+| `actor_player_id`           | Qui a fait l'action (vide si c'est le système : un cron, un admin)                   |
+| `target_type` + `target_id` | Sur quoi porte l'action (un personnage, un fruit, un navire…). Volontairement libre. |
+| `payload`                   | Les détails spécifiques au type d'action, en JSON                                    |
+| `source`                    | D'où vient l'action : bouton Discord, commande, cron, admin                          |
+
+> `target_id` peut pointer vers n'importe quelle table, donc on ne met pas de clé étrangère dessus. C'est voulu : ça nous laisse libres d'effacer de vieilles entrées plus tard sans casser de contraintes.
+
+### Convention de nommage
+
+Format : `<domaine>.<action_au_passé>`. Exemples :
+
+- `crew.captain_changed`
+- `island.refused`
+- `fruit.eaten`
+- `ship.upgraded`
+
+## Code applicatif
+
+### Un seul helper : `appendHistory`
+
+Tout passe par `appendHistory(...)`, dans `apps/bot/src/domains/history/`.
+
+```ts
+appendHistory({
+  type: 'crew.captain_changed', // l'IDE auto-complète le payload selon le type
+  payload: { fromCharacterInstanceId, toCharacterInstanceId },
+  actorPlayerId: player.id,
+  target: { type: 'character_instance', id: instanceId },
+  source: 'discord_button',
+  client: transaction, // optionnel — voir ci-dessous
+});
+```
+
+### Atomicité avec l'action métier
+
+Quand le log doit être indissociable de l'action (ex. `crew.captain_changed` ne doit pas exister si l'UPDATE du capitaine a échoué), on passe la transaction Drizzle via `client`. Le helper écrit alors dans la même transaction que l'action.
+
+Si l'action et le log sont indépendants, on omet `client` (le helper utilise `db` par défaut).
+
+### Ajouter un nouveau type
+
+Les types des payloads sont déclarés dans `apps/bot/src/domains/history/types/`, **un fichier par domaine métier** (`crew.ts`, `ship.ts`, `fruit.ts`…). Chaque fichier exporte l'union des logs de son domaine, et `types/index.ts` agrège l'union finale `Log`.
+
+Pour ajouter un type :
+
+1. Créer (ou compléter) le fichier du domaine concerné dans `types/`.
+2. Ajouter le nouveau type à l'union du domaine.
+3. Si c'est un nouveau domaine : l'ajouter à l'union centrale dans `types/index.ts`.
+4. Documenter le payload dans le catalogue ci-dessous.
+5. Appeler `appendHistory` depuis le service métier.
+
+## Catalogue des types
+
+> Liste vivante. Chaque entrée décrit la forme attendue du `payload`.
+
+### `crew.captain_changed`
+
+Le capitaine d'équipage d'un joueur change.
+
+```ts
+payload: {
+  fromCharacterInstanceId: number | null; // null si pas de capitaine avant
+  toCharacterInstanceId: number;
+}
+target: { type: 'character_instance', id: <nouveau capitaine> }
+actorPlayerId: <joueur>
+```

--- a/docs/domains/history.md
+++ b/docs/domains/history.md
@@ -40,7 +40,6 @@ Une seule table, avec quelques colonnes fixes pour les questions qu'on posera so
 | `actor_player_id`           | Qui a fait l'action (vide si c'est le système : un cron, un admin)                   |
 | `target_type` + `target_id` | Sur quoi porte l'action (un personnage, un fruit, un navire…). Volontairement libre. |
 | `payload`                   | Les détails spécifiques au type d'action, en JSON                                    |
-| `source`                    | D'où vient l'action : bouton Discord, commande, cron, admin                          |
 
 > `target_id` peut pointer vers n'importe quelle table, donc on ne met pas de clé étrangère dessus. C'est voulu : ça nous laisse libres d'effacer de vieilles entrées plus tard sans casser de contraintes.
 
@@ -65,7 +64,6 @@ appendHistory({
   payload: { fromCharacterInstanceId, toCharacterInstanceId },
   actorPlayerId: player.id,
   target: { type: 'character_instance', id: instanceId },
-  source: 'discord_button',
   client: transaction, // optionnel — voir ci-dessous
 });
 ```

--- a/packages/db/drizzle/0022_kameto_deban_moi_stp.sql
+++ b/packages/db/drizzle/0022_kameto_deban_moi_stp.sql
@@ -5,8 +5,7 @@ CREATE TABLE "history" (
 	"actor_player_id" integer,
 	"target_type" text,
 	"target_id" integer,
-	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"source" text
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL
 );
 --> statement-breakpoint
 ALTER TABLE "history" ADD CONSTRAINT "history_actor_player_id_player_id_fk" FOREIGN KEY ("actor_player_id") REFERENCES "public"."player"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint

--- a/packages/db/drizzle/0022_kameto_deban_moi_stp.sql
+++ b/packages/db/drizzle/0022_kameto_deban_moi_stp.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "history" (
+	"id" bigserial PRIMARY KEY NOT NULL,
+	"occurred_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"event_type" text NOT NULL,
+	"actor_player_id" integer,
+	"target_type" text,
+	"target_id" integer,
+	"payload" jsonb DEFAULT '{}'::jsonb NOT NULL,
+	"source" text
+);
+--> statement-breakpoint
+ALTER TABLE "history" ADD CONSTRAINT "history_actor_player_id_player_id_fk" FOREIGN KEY ("actor_player_id") REFERENCES "public"."player"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "history_occurred_at_idx" ON "history" USING btree ("occurred_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "history_event_type_occurred_at_idx" ON "history" USING btree ("event_type","occurred_at" DESC NULLS LAST);--> statement-breakpoint
+CREATE INDEX "history_actor_player_id_occurred_at_idx" ON "history" USING btree ("actor_player_id","occurred_at" DESC NULLS LAST) WHERE "history"."actor_player_id" IS NOT NULL;--> statement-breakpoint
+CREATE INDEX "history_target_idx" ON "history" USING btree ("target_type","target_id") WHERE "history"."target_id" IS NOT NULL;

--- a/packages/db/drizzle/meta/0022_snapshot.json
+++ b/packages/db/drizzle/meta/0022_snapshot.json
@@ -1,0 +1,1066 @@
+{
+  "id": "55c38e45-dacd-41d4-9ce8-84d95c1deb5c",
+  "prevId": "98a97b9a-5b09-4ead-adb5-9815e1ad7cce",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_instance": {
+      "name": "character_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_crew_at": {
+          "name": "joined_crew_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_captain": {
+          "name": "is_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "devil_fruit_template_id": {
+          "name": "devil_fruit_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_instance_player_template_uniq": {
+          "name": "character_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "character_instance_one_captain_per_player": {
+          "name": "character_instance_one_captain_per_player",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"character_instance\".\"is_captain\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_instance_template_id_character_template_id_fk": {
+          "name": "character_instance_template_id_character_template_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "character_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "character_instance_player_id_player_id_fk": {
+          "name": "character_instance_player_id_player_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_instance_devil_fruit_template_id_devil_fruit_template_id_fk": {
+          "name": "character_instance_devil_fruit_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "devil_fruit_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "character_instance_captain_must_be_in_crew": {
+          "name": "character_instance_captain_must_be_in_crew",
+          "value": "NOT \"character_instance\".\"is_captain\" OR \"character_instance\".\"joined_crew_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.character_template": {
+      "name": "character_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "combat": {
+          "name": "combat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "devil_fruit_template_id": {
+          "name": "devil_fruit_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "race": {
+          "name": "race",
+          "type": "character_race",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_template_name_trgm_idx": {
+          "name": "character_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_template_devil_fruit_template_id_devil_fruit_template_id_fk": {
+          "name": "character_template_devil_fruit_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "character_template",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "devil_fruit_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_template_name_unique": {
+          "name": "character_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_instance": {
+      "name": "devil_fruit_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_instance_player_template_uniq": {
+          "name": "devil_fruit_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devil_fruit_instance_template_id_devil_fruit_template_id_fk": {
+          "name": "devil_fruit_instance_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "devil_fruit_instance_player_id_player_id_fk": {
+          "name": "devil_fruit_instance_player_id_player_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_template": {
+      "name": "devil_fruit_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "devil_fruit_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::devil_fruit_type[]"
+        },
+        "hp_bonus": {
+          "name": "hp_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_bonus": {
+          "name": "combat_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_template_name_trgm_idx": {
+          "name": "devil_fruit_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devil_fruit_template_name_unique": {
+          "name": "devil_fruit_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_player_id": {
+          "name": "actor_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "history_occurred_at_idx": {
+          "name": "history_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_event_type_occurred_at_idx": {
+          "name": "history_event_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_actor_player_id_occurred_at_idx": {
+          "name": "history_actor_player_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "actor_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"history\".\"actor_player_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_target_idx": {
+          "name": "history_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"history\".\"target_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "history_actor_player_id_player_id_fk": {
+          "name": "history_actor_player_id_player_id_fk",
+          "tableFrom": "history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "actor_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player": {
+      "name": "player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "karma": {
+          "name": "karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounty": {
+          "name": "bounty",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "berries": {
+          "name": "berries",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_discord_id_unique": {
+          "name": "player_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_instance": {
+      "name": "resource_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_instance_player_template_uniq": {
+          "name": "resource_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_instance_template_id_resource_template_id_fk": {
+          "name": "resource_instance_template_id_resource_template_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "resource_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "resource_instance_player_id_player_id_fk": {
+          "name": "resource_instance_player_id_player_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_instance_quantity_non_negative": {
+          "name": "resource_instance_quantity_non_negative",
+          "value": "\"resource_instance\".\"quantity\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.resource_template": {
+      "name": "resource_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_template_name_trgm_idx": {
+          "name": "resource_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_template_name_unique": {
+          "name": "resource_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ship": {
+      "name": "ship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "hull_level": {
+          "name": "hull_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sail_level": {
+          "name": "sail_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "decks_level": {
+          "name": "decks_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cabins_level": {
+          "name": "cabins_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cargo_level": {
+          "name": "cargo_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ship_player_id_player_id_fk": {
+          "name": "ship_player_id_player_id_fk",
+          "tableFrom": "ship",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ship_player_id_unique": {
+          "name": "ship_player_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.character_race": {
+      "name": "character_race",
+      "schema": "public",
+      "values": [
+        "HUMAN",
+        "MINK",
+        "FISHMAN",
+        "GIANT",
+        "LUNARIAN",
+        "SKYPIEAN",
+        "CYBORG",
+        "MERMAID",
+        "DWARF"
+      ]
+    },
+    "public.devil_fruit_type": {
+      "name": "devil_fruit_type",
+      "schema": "public",
+      "values": [
+        "FEU",
+        "GLACE",
+        "MAGMA",
+        "FOUDRE",
+        "TENEBRES",
+        "LUMIERE",
+        "SABLE",
+        "GAZ",
+        "CAOUTCHOUC",
+        "POISON"
+      ]
+    },
+    "public.rarity": {
+      "name": "rarity",
+      "schema": "public",
+      "values": [
+        "COMMON",
+        "RARE",
+        "VERY_RARE",
+        "LEGENDARY"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/0022_snapshot.json
+++ b/packages/db/drizzle/meta/0022_snapshot.json
@@ -527,12 +527,6 @@
           "primaryKey": false,
           "notNull": true,
           "default": "'{}'::jsonb"
-        },
-        "source": {
-          "name": "source",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": false
         }
       },
       "indexes": {

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -155,6 +155,13 @@
       "when": 1777615679964,
       "tag": "0021_medecin_avec_frontiere_bardella_2026",
       "breakpoints": true
+    },
+    {
+      "idx": 22,
+      "version": "7",
+      "when": 1777640285756,
+      "tag": "0022_kameto_deban_moi_stp",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/domains/history/index.ts
+++ b/packages/db/src/domains/history/index.ts
@@ -1,0 +1,1 @@
+export { history, type HistoryEntry } from './schema.js';

--- a/packages/db/src/domains/history/schema.ts
+++ b/packages/db/src/domains/history/schema.ts
@@ -1,0 +1,32 @@
+import { sql } from 'drizzle-orm';
+import { bigserial, index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+
+import { player } from '../player/schema.js';
+
+export const history = pgTable(
+  'history',
+  {
+    id: bigserial('id', { mode: 'bigint' }).primaryKey(),
+    occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull().defaultNow(),
+    eventType: text('event_type').notNull(),
+    actorPlayerId: integer('actor_player_id').references(() => player.id, { onDelete: 'set null' }),
+    targetType: text('target_type'),
+    targetId: integer('target_id'),
+    payload: jsonb('payload')
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    source: text('source'),
+  },
+  (table) => [
+    index('history_occurred_at_idx').on(table.occurredAt.desc()),
+    index('history_event_type_occurred_at_idx').on(table.eventType, table.occurredAt.desc()),
+    index('history_actor_player_id_occurred_at_idx')
+      .on(table.actorPlayerId, table.occurredAt.desc())
+      .where(sql`${table.actorPlayerId} IS NOT NULL`),
+    index('history_target_idx')
+      .on(table.targetType, table.targetId)
+      .where(sql`${table.targetId} IS NOT NULL`),
+  ],
+);
+
+export type HistoryEntry = typeof history.$inferSelect;

--- a/packages/db/src/domains/history/schema.ts
+++ b/packages/db/src/domains/history/schema.ts
@@ -15,7 +15,6 @@ export const history = pgTable(
     payload: jsonb('payload')
       .notNull()
       .default(sql`'{}'::jsonb`),
-    source: text('source'),
   },
   (table) => [
     index('history_occurred_at_idx').on(table.occurredAt.desc()),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,4 +1,5 @@
 export { devilFruitInstance, devilFruitTemplate, devilFruitType } from './domains/devil_fruit/index.js';
+export { history } from './domains/history/index.js';
 export { player } from './domains/player/index.js';
 export { ship } from './domains/ship/index.js';
 export { resourceInstance, resourceTemplate } from './domains/resource/index.js';


### PR DESCRIPTION
## Résumé
- Ajout du nouveau domaine `history`, la table qui permet de retracer toutes les actions d'un joueur sur toute sa vie.
- Ajout d'un exemple pour quand on replace un capitaine 
- Documente le domaine dans `docs/domains/history.md` (à quoi ça sert, règles, comment ajouter un type) et l'ajoute à l'index dans `docs/architecture.md`