### PR TITLE
add player guild origine

### DIFF
--- a/apps/bot/src/discord/router.ts
+++ b/apps/bot/src/discord/router.ts
@@ -43,7 +43,7 @@ export async function routeMessage(message: Message, prefix: string): Promise<vo
 
     if (command.adminOnly === true) {
       const user = getSelfUser(message);
-      const { player } = await findOrCreatePlayer(user.id, user.username);
+      const { player } = await findOrCreatePlayer(user.id, user.username, message.guildId!);
       if (!player.isAdmin) {
         throw new AdminOnlyError();
       }

--- a/apps/bot/src/domains/_dev/commands/buy.ts
+++ b/apps/bot/src/domains/_dev/commands/buy.ts
@@ -9,7 +9,7 @@ export const buyCommand: Command = {
   async handler(message, args) {
     const amount = BigInt(args[0] ?? '0');
     const user = getSelfUser(message);
-    const { player } = await findOrCreatePlayer(user.id, user.username);
+    const { player } = await findOrCreatePlayer(user.id, user.username, message.guildId!);
     const newBerriesAmount = await buy(player.id, amount);
     await message.reply(`-${formatBerry(amount)} (solde : ${formatBerry(newBerriesAmount)})`);
   },

--- a/apps/bot/src/domains/_dev/commands/debug/player.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/player.ts
@@ -6,7 +6,7 @@ import { replyDebugData } from './utils.js';
 
 export const handlePlayer: Command['handler'] = async (message) => {
   const target = getTargetUser(message);
-  const { player } = await findOrCreatePlayer(target.id, target.username);
+  const { player } = await findOrCreatePlayer(target.id, target.username, message.guildId!);
 
   await replyDebugData(message, player);
 };

--- a/apps/bot/src/domains/_dev/commands/debug/ship.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/ship.ts
@@ -8,7 +8,7 @@ import { replyDebugData } from './utils.js';
 
 export const handleShip: Command['handler'] = async (message) => {
   const target = getTargetUser(message);
-  const { player } = await findOrCreatePlayer(target.id, target.username);
+  const { player } = await findOrCreatePlayer(target.id, target.username, message.guildId!);
   const ship = await shipRepository.findByPlayerId(player.id);
 
   if (!ship) {

--- a/apps/bot/src/domains/_dev/commands/givecharacter.ts
+++ b/apps/bot/src/domains/_dev/commands/givecharacter.ts
@@ -17,7 +17,7 @@ export const giveCharacterCommand: Command = {
       throw new NotFoundError(`Aucun personnage trouvé pour ${query}.`);
     }
 
-    const { player } = await findOrCreatePlayer(target.id, target.username);
+    const { player } = await findOrCreatePlayer(target.id, target.username, message.guildId!);
     const createdInstance = await characterRepository.createCharacterInstance(player.id, hit.entity.id);
 
     await message.reply({ embeds: [buildOpEmbed().setDescription(`${player.name} a reçu ${createdInstance.name}.`)] });

--- a/apps/bot/src/domains/_dev/commands/sell.ts
+++ b/apps/bot/src/domains/_dev/commands/sell.ts
@@ -9,7 +9,7 @@ export const sellCommand: Command = {
   async handler(message, args) {
     const amount = BigInt(args[0] ?? '0');
     const user = getSelfUser(message);
-    const { player } = await findOrCreatePlayer(user.id, user.username);
+    const { player } = await findOrCreatePlayer(user.id, user.username, message.guildId!);
     const newBerriesAmount = await sell(player.id, amount);
     await message.reply(`+${formatBerry(amount)} (solde : ${formatBerry(newBerriesAmount)})`);
   },

--- a/apps/bot/src/domains/crew/commands/change-captain.ts
+++ b/apps/bot/src/domains/crew/commands/change-captain.ts
@@ -15,7 +15,7 @@ export const changeCaptainCommand: Command = {
   name: 'changecaptain',
   async handler(message) {
     const user = getSelfUser(message);
-    const { player } = await findOrCreatePlayer(user.id, user.username);
+    const { player } = await findOrCreatePlayer(user.id, user.username, message.guildId!);
     const crew = await getCrewByPlayerId(player.id);
 
     if (crew.length === 1) {

--- a/apps/bot/src/domains/crew/commands/crew.ts
+++ b/apps/bot/src/domains/crew/commands/crew.ts
@@ -11,7 +11,7 @@ export const crewCommand: Command = {
   name: 'crew',
   async handler(message) {
     const target = getTargetUser(message);
-    const { player } = await findOrCreatePlayer(target.id, target.username);
+    const { player } = await findOrCreatePlayer(target.id, target.username, message.guildId!);
     const ship = await shipRepository.findByPlayerIdOrThrow(player.id);
     const characters = await getCharactersByPlayerId(player.id);
     await message.reply(buildCrewView(player, ship, characters, 0, message.author.id));

--- a/apps/bot/src/domains/crew/interactions/set-captain.ts
+++ b/apps/bot/src/domains/crew/interactions/set-captain.ts
@@ -15,7 +15,7 @@ async function handle(interaction: ButtonInteraction, args: Array<string>): Prom
   const targetInstanceId = parseIntegerArg(args[0]);
 
   const interactionUser = interaction.user;
-  const { player } = await findOrCreatePlayer(interactionUser.id, interactionUser.username);
+  const { player } = await findOrCreatePlayer(interactionUser.id, interactionUser.username, interaction.guildId!);
 
   const targetInstance = await crewRepository.findCharacterInstanceById(targetInstanceId);
   const ownerPlayerId = targetInstance?.playerId;

--- a/apps/bot/src/domains/fishing/commands/fishing.ts
+++ b/apps/bot/src/domains/fishing/commands/fishing.ts
@@ -7,7 +7,7 @@ export const fishingCommand: Command = {
   name: ['fishing', 'fish'],
   async handler(message) {
     const user = getTargetUser(message);
-    const { player } = await findOrCreatePlayer(user.id, user.username);
+    const { player } = await findOrCreatePlayer(user.id, user.username, message.guildId!);
     const result = await runFishingAttempt(player.id);
 
     const embed = buildOpEmbed()

--- a/apps/bot/src/domains/player/commands/karma.ts
+++ b/apps/bot/src/domains/player/commands/karma.ts
@@ -6,7 +6,7 @@ import { findOrCreatePlayer } from '../service.js';
 export const karmaCommand: Command = {
   name: 'karma',
   async handler(message) {
-    const { player } = await findOrCreatePlayer(message.author.id, message.author.username);
+    const { player } = await findOrCreatePlayer(message.author.id, message.author.username, message.guildId!);
     const grade = getKarmaGrade(player.karma);
     await message.reply(`Karma: ${grade} (${player.karma})`);
   },

--- a/apps/bot/src/domains/player/commands/profil.ts
+++ b/apps/bot/src/domains/player/commands/profil.ts
@@ -7,7 +7,7 @@ export const profilCommand: Command = {
   name: 'profil',
   async handler(message) {
     const target = getTargetUser(message);
-    const { player } = await findOrCreatePlayer(target.id, target.username);
+    const { player } = await findOrCreatePlayer(target.id, target.username, message.guildId!);
     await message.reply(await buildProfilView(player.id, message.author.id));
   },
 };

--- a/apps/bot/src/domains/player/commands/rename.ts
+++ b/apps/bot/src/domains/player/commands/rename.ts
@@ -6,7 +6,7 @@ export const renameCommand: Command = {
   name: 'rename',
   async handler(message, args) {
     try {
-      const { player } = await findOrCreatePlayer(message.author.id, message.author.username);
+      const { player } = await findOrCreatePlayer(message.author.id, message.author.username, message.guildId!);
       const renamed = await renamePlayer(player.id, args.join(' '));
       await message.reply({
         content: `Tu t'appelles maintenant ${renamed.name}.`,

--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -22,9 +22,9 @@ export async function findByDiscordId(discordId: string): Promise<Player | undef
 // TODO: remplacer par bucketIdFromTimestamp (#174) une fois mergé
 const BUCKET_DURATION_SECONDS = 15 * 60;
 
-export async function create(discordId: string, name: string, transaction: DbOrTransaction = db): Promise<Player> {
+export async function create(discordId: string, name: string, originGuildId: string, transaction: DbOrTransaction = db): Promise<Player> {
   const lastProcessedBucketId = Math.floor(Date.now() / 1000 / BUCKET_DURATION_SECONDS);
-  const [row] = await transaction.insert(player).values({ discordId, name, lastProcessedBucketId }).returning();
+  const [row] = await transaction.insert(player).values({ discordId, name, originGuildId, lastProcessedBucketId }).returning();
   return row!;
 }
 

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -12,12 +12,12 @@ type FindOrCreateResult = {
   created: boolean;
 };
 
-export async function findOrCreatePlayer(discordId: string, name: string): Promise<FindOrCreateResult> {
+export async function findOrCreatePlayer(discordId: string, name: string, guildId: string): Promise<FindOrCreateResult> {
   const existing = await playerRepository.findByDiscordId(discordId);
   if (existing) return { player: existing, created: false };
 
   const created = await db.transaction(async (transaction) => {
-    const newPlayer = await playerRepository.create(discordId, name, transaction);
+    const newPlayer = await playerRepository.create(discordId, name, guildId, transaction);
     await characterRepository.createPlayerAsCharacterInstance(newPlayer.id, newPlayer.name, transaction);
     await findOrCreateShip(newPlayer.id, undefined, transaction);
     return newPlayer;

--- a/apps/bot/src/domains/resource/commands/inventaire.ts
+++ b/apps/bot/src/domains/resource/commands/inventaire.ts
@@ -8,7 +8,7 @@ export const inventaireCommand: Command = {
   name: 'inventaire',
   async handler(message) {
     const target = getTargetUser(message);
-    const { player } = await findOrCreatePlayer(target.id, target.username);
+    const { player } = await findOrCreatePlayer(target.id, target.username, message.guildId!);
     const inventory = await getInventory(player.id);
 
     await message.reply(buildInventoryView(player, inventory, 0, message.author.id));

--- a/apps/bot/src/domains/ship/commands/rename.ts
+++ b/apps/bot/src/domains/ship/commands/rename.ts
@@ -8,7 +8,7 @@ export const renameShipCommand: Command = {
   name: 'renameship',
   async handler(message, args) {
     try {
-      const { player } = await findOrCreatePlayer(message.author.id, message.author.username);
+      const { player } = await findOrCreatePlayer(message.author.id, message.author.username, message.guildId!);
       const renamed = await renameShip(player.id, args.join(' '));
 
       const embed = buildOpEmbed().setTitle('Bateau renommé !').setDescription(`Ton bateau s'appelle maintenant **${renamed.name}**.`);

--- a/apps/bot/src/domains/ship/commands/ship.ts
+++ b/apps/bot/src/domains/ship/commands/ship.ts
@@ -7,7 +7,7 @@ export const shipCommand: Command = {
   name: 'ship',
   async handler(message) {
     const user = getTargetUser(message);
-    const { player } = await findOrCreatePlayer(user.id, user.username);
+    const { player } = await findOrCreatePlayer(user.id, user.username, message.guildId!);
     await message.reply(await buildShipView(player.id, message.author.id));
   },
 };

--- a/packages/db/drizzle/0027_terrain_moisi_de_vincenne.sql
+++ b/packages/db/drizzle/0027_terrain_moisi_de_vincenne.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "player" ADD COLUMN "origin_guild_id" varchar(32) NOT NULL;--> statement-breakpoint
+ALTER TABLE "player" ADD CONSTRAINT "player_origin_guild_id_guild_id_fk" FOREIGN KEY ("origin_guild_id") REFERENCES "public"."guild"("id") ON DELETE no action ON UPDATE no action;

--- a/packages/db/drizzle/meta/0027_snapshot.json
+++ b/packages/db/drizzle/meta/0027_snapshot.json
@@ -1,0 +1,1239 @@
+{
+  "id": "9c4f0b56-7a09-4986-bc0a-84af1418c09a",
+  "prevId": "7d766a81-4b13-49e6-ba52-d7acc820a341",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_instance": {
+      "name": "character_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_crew_at": {
+          "name": "joined_crew_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_captain": {
+          "name": "is_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "devil_fruit_template_id": {
+          "name": "devil_fruit_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_instance_player_template_uniq": {
+          "name": "character_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "character_instance_one_captain_per_player": {
+          "name": "character_instance_one_captain_per_player",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"character_instance\".\"is_captain\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_instance_template_id_character_template_id_fk": {
+          "name": "character_instance_template_id_character_template_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "character_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "character_instance_player_id_player_id_fk": {
+          "name": "character_instance_player_id_player_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_instance_devil_fruit_template_id_devil_fruit_template_id_fk": {
+          "name": "character_instance_devil_fruit_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "devil_fruit_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "character_instance_captain_must_be_in_crew": {
+          "name": "character_instance_captain_must_be_in_crew",
+          "value": "NOT \"character_instance\".\"is_captain\" OR \"character_instance\".\"joined_crew_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.character_template": {
+      "name": "character_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "combat": {
+          "name": "combat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "devil_fruit_template_id": {
+          "name": "devil_fruit_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "race": {
+          "name": "race",
+          "type": "character_race",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_template_name_trgm_idx": {
+          "name": "character_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_template_devil_fruit_template_id_devil_fruit_template_id_fk": {
+          "name": "character_template_devil_fruit_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "character_template",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "devil_fruit_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_template_name_unique": {
+          "name": "character_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_instance": {
+      "name": "devil_fruit_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_instance_player_template_uniq": {
+          "name": "devil_fruit_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devil_fruit_instance_template_id_devil_fruit_template_id_fk": {
+          "name": "devil_fruit_instance_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "devil_fruit_instance_player_id_player_id_fk": {
+          "name": "devil_fruit_instance_player_id_player_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_template": {
+      "name": "devil_fruit_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "devil_fruit_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::devil_fruit_type[]"
+        },
+        "hp_bonus": {
+          "name": "hp_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_bonus": {
+          "name": "combat_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_template_name_trgm_idx": {
+          "name": "devil_fruit_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devil_fruit_template_name_unique": {
+          "name": "devil_fruit_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_instance": {
+      "name": "event_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_interactive": {
+          "name": "is_interactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_instance_player_event_key_bucket_uniq": {
+          "name": "event_instance_player_event_key_bucket_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_instance_player_id_player_id_fk": {
+          "name": "event_instance_player_id_player_id_fk",
+          "tableFrom": "event_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guild": {
+      "name": "guild",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fr'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'!'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_player_id": {
+          "name": "actor_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "history_occurred_at_idx": {
+          "name": "history_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_event_type_occurred_at_idx": {
+          "name": "history_event_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_actor_player_id_occurred_at_idx": {
+          "name": "history_actor_player_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "actor_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"history\".\"actor_player_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_target_idx": {
+          "name": "history_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"history\".\"target_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "history_actor_player_id_player_id_fk": {
+          "name": "history_actor_player_id_player_id_fk",
+          "tableFrom": "history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "actor_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player": {
+      "name": "player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_guild_id": {
+          "name": "origin_guild_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "karma": {
+          "name": "karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bounty": {
+          "name": "bounty",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "berries": {
+          "name": "berries",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_processed_bucket_id": {
+          "name": "last_processed_bucket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_origin_guild_id_guild_id_fk": {
+          "name": "player_origin_guild_id_guild_id_fk",
+          "tableFrom": "player",
+          "tableTo": "guild",
+          "columnsFrom": [
+            "origin_guild_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_discord_id_unique": {
+          "name": "player_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_instance": {
+      "name": "resource_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_instance_player_template_uniq": {
+          "name": "resource_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_instance_template_id_resource_template_id_fk": {
+          "name": "resource_instance_template_id_resource_template_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "resource_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "resource_instance_player_id_player_id_fk": {
+          "name": "resource_instance_player_id_player_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_instance_quantity_non_negative": {
+          "name": "resource_instance_quantity_non_negative",
+          "value": "\"resource_instance\".\"quantity\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.resource_template": {
+      "name": "resource_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_template_name_trgm_idx": {
+          "name": "resource_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_template_name_unique": {
+          "name": "resource_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ship": {
+      "name": "ship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "hull_level": {
+          "name": "hull_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sail_level": {
+          "name": "sail_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "decks_level": {
+          "name": "decks_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cabins_level": {
+          "name": "cabins_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cargo_level": {
+          "name": "cargo_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ship_player_id_player_id_fk": {
+          "name": "ship_player_id_player_id_fk",
+          "tableFrom": "ship",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ship_player_id_unique": {
+          "name": "ship_player_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.character_race": {
+      "name": "character_race",
+      "schema": "public",
+      "values": [
+        "HUMAN",
+        "MINK",
+        "FISHMAN",
+        "GIANT",
+        "LUNARIAN",
+        "SKYPIEAN",
+        "CYBORG",
+        "MERMAID",
+        "DWARF"
+      ]
+    },
+    "public.devil_fruit_type": {
+      "name": "devil_fruit_type",
+      "schema": "public",
+      "values": [
+        "FEU",
+        "GLACE",
+        "MAGMA",
+        "FOUDRE",
+        "TENEBRES",
+        "LUMIERE",
+        "SABLE",
+        "GAZ",
+        "CAOUTCHOUC",
+        "POISON"
+      ]
+    },
+    "public.rarity": {
+      "name": "rarity",
+      "schema": "public",
+      "values": [
+        "COMMON",
+        "RARE",
+        "VERY_RARE",
+        "LEGENDARY"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1777616819773,
       "tag": "0026_un_chikwangue_par_jour",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1777967677629,
+      "tag": "0027_terrain_moisi_de_vincenne",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/domains/player/schema.ts
+++ b/packages/db/src/domains/player/schema.ts
@@ -3,11 +3,16 @@ import { pgTable, serial, varchar, bigint, integer, boolean } from 'drizzle-orm/
 
 import { MAX_CHARACTER_NAME_LENGTH } from '../../shared/constants.js';
 import { timestamps } from '../../shared/helpers.js';
+import { guild } from '../guild/schema.js';
 
 export const player = pgTable('player', {
   id: serial('id').primaryKey(),
 
   discordId: varchar('discord_id', { length: 32 }).notNull().unique(),
+
+  originGuildId: varchar('origin_guild_id', { length: 32 })
+    .notNull()
+    .references(() => guild.id),
 
   // Karma interne : -1000 à +1000 (contrôlé côté app)
   karma: integer('karma').notNull().default(0),


### PR DESCRIPTION
## Résumé

- Ajout de `player.origin_guild_id` avec une FK vers `guild.id`.
- Passage du `guildId` à `findOrCreatePlayer` pour figer le serveur d’origine à la création du joueur.
- Mise à jour des appels à `findOrCreatePlayer` pour transmettre `message.guildId` ou `interaction.guildId`.
- Ajout de la migration Drizzle correspondante.

## Note sur le type de `origin_guild_id`

Le ticket demandait `origin_guild_id text NOT NULL`, mais j’ai utilisé `varchar(32)` dans le schéma Drizzle parce que la colonne référencée `guild.id` est déjà définie en `varchar(32)`.

Comme `origin_guild_id` est une FK vers `guild.id`, garder exactement le même type côté application et DB évite (d'après l'ia) une incohérence de modèle entre les deux tables. Fonctionnellement, ça reste adapté à l’ID Discord de guild, et ça respecte l’intention du ticket : stocker l’ID du serveur d’origine sans default et sans le modifier après création.

j'attends ton retour