### PR TITLE
add getPendingEventsForPlayer

### DIFF
--- a/apps/bot/src/domains/event/index.ts
+++ b/apps/bot/src/domains/event/index.ts
@@ -1,0 +1,1 @@
+export { getPendingEventsForPlayer, type PendingEventInstance } from './repository.js';

--- a/apps/bot/src/domains/event/repository.ts
+++ b/apps/bot/src/domains/event/repository.ts
@@ -1,0 +1,30 @@
+import { db, eventInstance } from '@one-piece/db';
+import { asc, eq } from 'drizzle-orm';
+
+export type PendingEventInstance = {
+  id: number;
+  type: string;
+  scope: 'passive' | 'interactive';
+  bucketId: number;
+  encounterId: number | null;
+  state: Record<string, unknown>;
+  createdAt: Date;
+};
+
+export async function getPendingEventsForPlayer(playerId: number): Promise<Array<PendingEventInstance>> {
+  const rows = await db
+    .select()
+    .from(eventInstance)
+    .where(eq(eventInstance.playerId, playerId))
+    .orderBy(asc(eventInstance.bucketId), asc(eventInstance.id));
+
+  return rows.map((row) => ({
+    id: Number(row.id),
+    type: row.eventKey,
+    scope: row.isInteractive ? 'interactive' : 'passive',
+    bucketId: row.bucketId,
+    encounterId: null,
+    state: row.state as Record<string, unknown>,
+    createdAt: row.createdAt,
+  }));
+}

--- a/apps/bot/src/domains/event/repository.ts
+++ b/apps/bot/src/domains/event/repository.ts
@@ -1,13 +1,8 @@
-import { db, eventInstance } from '@one-piece/db';
+import { db, eventInstance, type EventInstance } from '@one-piece/db';
 import { asc, eq } from 'drizzle-orm';
 
-export type PendingEventInstance = {
-  id: bigint;
-  eventKey: string;
-  isInteractive: boolean;
-  bucketId: number;
+export type PendingEventInstance = Omit<EventInstance, 'playerId' | 'state'> & {
   state: Record<string, unknown>;
-  createdAt: Date;
 };
 
 export async function getPendingEventsForPlayer(playerId: number): Promise<Array<PendingEventInstance>> {

--- a/apps/bot/src/domains/event/repository.ts
+++ b/apps/bot/src/domains/event/repository.ts
@@ -2,11 +2,10 @@ import { db, eventInstance } from '@one-piece/db';
 import { asc, eq } from 'drizzle-orm';
 
 export type PendingEventInstance = {
-  id: number;
-  type: string;
-  scope: 'passive' | 'interactive';
+  id: bigint;
+  eventKey: string;
+  isInteractive: boolean;
   bucketId: number;
-  encounterId: number | null;
   state: Record<string, unknown>;
   createdAt: Date;
 };
@@ -19,11 +18,10 @@ export async function getPendingEventsForPlayer(playerId: number): Promise<Array
     .orderBy(asc(eventInstance.bucketId), asc(eventInstance.id));
 
   return rows.map((row) => ({
-    id: Number(row.id),
-    type: row.eventKey,
-    scope: row.isInteractive ? 'interactive' : 'passive',
+    id: row.id,
+    eventKey: row.eventKey,
+    isInteractive: row.isInteractive,
     bucketId: row.bucketId,
-    encounterId: null,
     state: row.state as Record<string, unknown>,
     createdAt: row.createdAt,
   }));

--- a/docs/domains/event/cross-player.md
+++ b/docs/domains/event/cross-player.md
@@ -19,13 +19,15 @@ Quand le moteur d'A processe ses buckets pendant un `!recap` :
 
 ## Première détection : INSERT pour les deux
 
+> // TODO: `encounter_id` n'est pas encore en schéma (cf `data-model.md`). Le mécanisme décrit ci-dessous est l'état cible.
+
 Quand A processe son bucket courant, le seed dit "encounter A-B", et B est synced past ce bucket :
 
 - INSERT `event_instance` pending **pour A** avec `encounter_id = X`.
 - INSERT `event_instance` pending **pour B** avec le même `encounter_id = X`.
 - `encounter_id = hash(bucket_id, sorted_player_ids)` → identique si B re-tire l'encounter de son côté plus tard.
 
-L'unicité `(player_id, type, bucket_id)` garantit pas de doublon : si B recap quelques secondes après A et re-tire le même encounter, l'INSERT échoue silencieusement.
+L'unicité `(player_id, event_key, bucket_id)` garantit pas de doublon : si B recap quelques secondes après A et re-tire le même encounter, l'INSERT échoue silencieusement.
 
 > **Race condition** = situation où le résultat dépend de l'ordre/timing entre opérations parallèles. Sans la contrainte d'unicité, deux INSERT simultanés pourraient créer des doublons. Avec, l'un gagne, l'autre échoue proprement.
 

--- a/docs/domains/event/data-model.md
+++ b/docs/domains/event/data-model.md
@@ -6,20 +6,20 @@ Deux tables, chacune avec un rôle clair. La position courante des joueurs (util
 
 Contient à la fois les passive en attente d'affichage et les interactive en attente de décision. Une ligne disparaît quand le joueur "consomme" l'event (clic "Suivant" pour passive, clic sur un choix pour interactive).
 
-| Colonne        | Type                           | Rôle                                                                                             |
-| -------------- | ------------------------------ | ------------------------------------------------------------------------------------------------ |
-| `id`           | bigserial PK                   | identifiant unique                                                                               |
-| `player_id`    | integer FK                     | propriétaire                                                                                     |
-| `type`         | text                           | identifiant du générateur (`mainstory.alabasta.find_map`)                                        |
-| `scope`        | enum `passive` / `interactive` | détermine le mode d'affichage (Suivant vs choix) et le timing des effets                         |
-| `bucket_id`    | bigint                         | bucket dans lequel l'event a été tiré (sert aussi à l'ordre d'affichage)                         |
-| `encounter_id` | bigint, null                   | relie les events cross-player (deux lignes liées)                                                |
-| `state`        | jsonb                          | passive : snapshot pour `render(state)` ; interactive multi-step : `{ step: 'haki_charged', … }` |
-| `created_at`   | timestamptz                    |                                                                                                  |
+| Colonne          | Type         | Rôle                                                                                             |
+| ---------------- | ------------ | ------------------------------------------------------------------------------------------------ |
+| `id`             | bigserial PK | identifiant unique                                                                               |
+| `player_id`      | integer FK   | propriétaire                                                                                     |
+| `event_key`      | text         | identifiant du générateur (`mainstory.alabasta.find_map`) — = `EventGenerator.type`              |
+| `is_interactive` | boolean      | détermine le mode d'affichage (Suivant vs choix) et le timing des effets                         |
+| `bucket_id`      | integer      | bucket dans lequel l'event a été tiré (sert aussi à l'ordre d'affichage)                         |
+| `encounter_id`   | bigint, null | relie les events cross-player (deux lignes liées) — // TODO: pas encore en schéma                |
+| `state`          | jsonb        | passive : snapshot pour `render(state)` ; interactive multi-step : `{ step: 'haki_charged', … }` |
+| `created_at`     | timestamptz  |                                                                                                  |
 
 > **`bigserial`** = compteur 64 bits auto-incrémenté. **PK** = primary key. **FK** = foreign key (Postgres garantit la référence). **`jsonb`** = JSON binaire interrogeable et indexable.
 
-**Contrainte unique : `(player_id, type, bucket_id)`** — base de l'**idempotence**. Si le calcul d'un bucket est rejoué (retry après échec de transaction, double `!recap`), le moteur regénère le même event depuis le même seed → INSERT en doublon refusé silencieusement.
+**Contrainte unique : `(player_id, event_key, bucket_id)`** — base de l'**idempotence**. Si le calcul d'un bucket est rejoué (retry après échec de transaction, double `!recap`), le moteur regénère le même event depuis le même seed → INSERT en doublon refusé silencieusement.
 
 > **Idempotence** = opération qu'on peut appeler N fois avec le même résultat qu'une seule. "Marquer comme lu" : idempotent. "Envoyer email" : non.
 

--- a/docs/domains/event/performance.md
+++ b/docs/domains/event/performance.md
@@ -26,7 +26,7 @@ ctx.history = {
 
 ## 2. Idempotence garantie par `event_instance`
 
-L'unicité `(player_id, type, bucket_id)` sur `event_instance` (cf [data-model.md](./data-model.md)) couvre tout : passive comme interactive y passent, donc un retry après échec ou un double `!recap` simultané se résout par un conflit refusé silencieusement.
+L'unicité `(player_id, event_key, bucket_id)` sur `event_instance` (cf [data-model.md](./data-model.md)) couvre tout : passive comme interactive y passent, donc un retry après échec ou un double `!recap` simultané se résout par un conflit refusé silencieusement.
 
 **Implémentation** : utiliser `INSERT ... ON CONFLICT DO NOTHING` côté engine. Sinon une ligne déjà tracée bloque toute la transaction du recap au moindre retry.
 

--- a/docs/domains/event/recap-flow.md
+++ b/docs/domains/event/recap-flow.md
@@ -75,7 +75,7 @@ Deux phases distinctes : **calcul** (rejouer les buckets, appliquer les effets, 
    - Sinon, continuer. Au dernier bucket processé, `last_processed_bucket_id = nowBucket - 1`.
 3. **Tout dans une seule transaction Drizzle.**
 
-> **Pourquoi marquer le bucket de l'interactive comme processé (et pas le précédent)** : le bucket interrompu a déjà été entièrement processé (passive matérialisés + interactive tiré). En l'enregistrant comme processé, on garantit qu'au prochain `!recap` (après résolution), l'engine reprend au bucket **suivant** et ne re-tire jamais ce bucket. Aucun risque de re-firer les passive déjà en queue ou déjà consommés. L'unicité `(player_id, type, bucket_id)` sur `event_instance` est un filet de sécurité, pas la défense de première ligne.
+> **Pourquoi marquer le bucket de l'interactive comme processé (et pas le précédent)** : le bucket interrompu a déjà été entièrement processé (passive matérialisés + interactive tiré). En l'enregistrant comme processé, on garantit qu'au prochain `!recap` (après résolution), l'engine reprend au bucket **suivant** et ne re-tire jamais ce bucket. Aucun risque de re-firer les passive déjà en queue ou déjà consommés. L'unicité `(player_id, event_key, bucket_id)` sur `event_instance` est un filet de sécurité, pas la défense de première ligne.
 
 > **Transaction** = bloc DB tout-ou-rien. Si l'INSERT d'un `event_instance` foire après application d'un effet passive (+50 berries), le joueur ne garde pas les berries sans la trace.
 
@@ -84,7 +84,7 @@ Deux phases distinctes : **calcul** (rejouer les buckets, appliquer les effets, 
 Lecture de la queue (ordonnée par `bucket_id`) et affichage du **premier** event :
 
 - **Queue vide** → "Vous n'avez aucun événement en attente."
-- **Passive en tête** → retrouver le générateur via `type`, appeler `render(state)`, afficher l'embed + bouton **Suivant**. Clic → DELETE l'`event_instance`, render le suivant.
+- **Passive en tête** → retrouver le générateur via `event_key`, appeler `render(state)`, afficher l'embed + bouton **Suivant**. Clic → DELETE l'`event_instance`, render le suivant.
 - **Interactive en tête** → appeler `steps[state.step].embed(state, ctx)` + boutons des choix. Clic sur un choix → appliquer les effets, DELETE `event_instance`, INSERT `history`, render le suivant (ou bien `goTo` une autre étape sans DELETE).
 
 Le joueur peut interrompre à tout moment : la queue persiste. Au prochain `!recap`, on recalcule les nouveaux buckets (s'il y en a) puis on reprend l'affichage en haut de queue. Pas de cooldown sur `!recap`.

--- a/packages/db/src/domains/event/event_instance/schema.ts
+++ b/packages/db/src/domains/event/event_instance/schema.ts
@@ -17,6 +17,7 @@ export const eventInstance = pgTable(
       .notNull()
       .default(sql`'{}'::jsonb`),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    // TODO: ajouter `encounter_id` (bigint nullable) pour relier les events cross-player (cf docs/domains/event/cross-player.md)
   },
   (table) => [uniqueIndex('event_instance_player_event_key_bucket_uniq').on(table.playerId, table.eventKey, table.bucketId)],
 );

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,3 +7,4 @@ export { type DevilFruitTemplate } from './domains/devil_fruit/index.js';
 export { PLAYER_AS_CHARACTER_TEMPLATE_NAME, type CharacterInstance, type CharacterTemplate } from './domains/character/index.js';
 export { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type Ship, type ShipModuleKey } from './domains/ship/index.js';
 export { type ResourceName, type ResourceTemplate } from './domains/resource/index.js';
+export { type EventInstance } from './domains/event/index.js';


### PR DESCRIPTION
## Contexte

Quand un joueur lance `!recap`, le bot doit pouvoir récupérer les événements encore en attente dans sa queue, afin d’afficher le prochain événement non consommé.

Cette PR ajoute le repository du domaine `event` côté bot avec une fonction dédiée à la lecture de cette queue.

## Changements

- Ajout de `apps/bot/src/domains/event/repository.ts`
- Ajout du type `PendingEventInstance`
- Ajout de `getPendingEventsForPlayer(playerId)`
- Tri des événements par `bucketId ASC`, puis `id ASC` pour garantir un ordre déterministe
- Export du repository via `apps/bot/src/domains/event/index.ts`

## Note sur `encounterId`

Le type demandé expose `encounterId`, mais le schéma actuel de la table `event_instance` ne contient pas encore de colonne `encounter_id` donc encounterId est mis à null

Pour rester compatible avec le contrat attendu sans inventer une donnée absente de la base, `encounterId` est donc retourné à `null`. Ce choix rend l’API prête pour l’ajout futur de la colonne, tout en évitant un mapping incorrect ou fragile aujourd’hui.
