### PR TITLE
added rng file

### DIFF
--- a/apps/bot/src/domains/event/engine/rng.ts
+++ b/apps/bot/src/domains/event/engine/rng.ts
@@ -1,5 +1,14 @@
+/**
+ * Un générateur de nombres pseudo-aléatoires (PRNG) qui produit des nombres dans [0, 1).
+ */
 export type Rng = { next: () => number };
 
+/**
+ * Hache une chaîne de caractères en un entier 32 bits via un hash polynomial.
+ *
+ * @param s - La chaîne à hacher.
+ * @returns Un entier 32 bits correspondant au hash de la chaîne.
+ */
 export function hashString(s: string): number {
   let hash = 0;
   for (const char of s) {
@@ -8,12 +17,41 @@ export function hashString(s: string): number {
   return hash;
 }
 
+/**
+ * Dérive une graine déterministe à partir d'un identifiant de bucket et d'un identifiant de zone.
+ * Deux appels avec les mêmes arguments produiront toujours la même graine.
+ *
+ * @param bucketId - L'identifiant du bucket.
+ * @param zoneId - L'identifiant textuel de la zone.
+ * @returns Un entier 32 bits utilisable comme graine.
+ */
 export function seedFromBucketAndZone(bucketId: number, zoneId: string): number {
   return hashString(zoneId) ^ (bucketId * 2654435761);
 }
+
+/**
+ * Dérive une graine déterministe à partir d'un identifiant de bucket et d'un identifiant de joueur.
+ * Deux appels avec les mêmes arguments produiront toujours la même graine.
+ *
+ * @param bucketId - L'identifiant du bucket.
+ * @param playerId - L'identifiant du joueur.
+ * @returns Un entier 32 bits utilisable comme graine.
+ */
 export function seedFromBucketAndPlayer(bucketId: number, playerId: number): number {
   return playerId ^ (bucketId * 2654435761);
 }
+
+/**
+ * Crée un PRNG à graine fixe basé sur un algorithme inspiré de Mulberry32.
+ * Le générateur est stateful — chaque appel à `next()` fait avancer l'état interne.
+ *
+ * @param seed - La valeur de graine initiale.
+ * @returns Une instance de {@link Rng} dont la méthode `next()` retourne un flottant dans [0, 1).
+ *
+ * @example
+ * const rng = createRng(seedFromBucketAndPlayer(1, 42));
+ * const valeur = rng.next(); // ex: 0.7281...
+ */
 export function createRng(seed: number): Rng {
   return {
     next() {

--- a/apps/bot/src/domains/event/engine/rng.ts
+++ b/apps/bot/src/domains/event/engine/rng.ts
@@ -1,0 +1,26 @@
+export type Rng = { next: () => number };
+
+export function hashString(s: string): number {
+  let hash = 0;
+  for (const char of s) {
+    hash = hash * 31 + char.charCodeAt(0);
+  }
+  return hash;
+}
+
+export function seedFromBucketAndZone(bucketId: number, zoneId: string): number {
+  return hashString(zoneId) ^ (bucketId * 2654435761);
+}
+export function seedFromBucketAndPlayer(bucketId: number, playerId: number): number {
+  return playerId ^ (bucketId * 2654435761);
+}
+export function createRng(seed: number): Rng {
+  return {
+    next() {
+      let t = (seed += 0x6d2b79f5);
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    },
+  };
+}


### PR DESCRIPTION
---

## ⚙️ feat : ajout du module RNG déterministe

### Contexte
Le moteur de `!recap` a besoin de prendre des décisions aléatoires reproductibles (ex : "y a-t-il un baril dans cette tranche de temps ?"). On utilise un PRNG initialisé par une seed — même seed = même séquence de nombres, ce que `Math.random()` ne permet pas.

### Ce qui a été ajouté
`apps/bot/src/domains/event/engine/rng.ts` qui exporte :
- `seedFromBucketAndZone(bucketId, zoneId)` — seed partagée entre tous les joueurs d'une zone (même rencontre pour tout le monde au même moment)
- `seedFromBucketAndPlayer(bucketId, playerId)` — seed isolée par joueur (événements personnels uniques)
- `createRng(seed)` — générateur mulberry32, simple et déterministe

### Pourquoi mulberry32
`Math.random()` ne prend pas de seed → impossible de reproduire une séquence. Mulberry32 est un PRNG léger, rapide et déterministe qui suffit largement pour notre usage.

### Fichiers modifiés
- `apps/bot/src/domains/event/engine/rng.ts` — nouveau fichier