### PR TITLE
IMPLEMENT event choice button

### DIFF
--- a/apps/bot/src/discord/errors.ts
+++ b/apps/bot/src/discord/errors.ts
@@ -36,8 +36,8 @@ export class ForbiddenError extends AppError {
 }
 
 export class InternalError extends AppError {
-  constructor(message: string) {
-    super(message, 'error', 'Une erreur est survenue, veuillez contacter un admin.');
+  constructor(message = 'Une erreur est survenue, veuillez contacter un admin.') {
+    super(message, 'error');
     this.name = 'InternalError';
   }
 }

--- a/apps/bot/src/discord/errors.ts
+++ b/apps/bot/src/discord/errors.ts
@@ -37,7 +37,7 @@ export class ForbiddenError extends AppError {
 
 export class InternalError extends AppError {
   constructor(message = 'Une erreur est survenue, veuillez contacter un admin.') {
-    super(message, 'error');
+    super(message, 'error', 'Une erreur est survenue, veuillez contacter un admin.');
     this.name = 'InternalError';
   }
 }

--- a/apps/bot/src/discord/utils/index.ts
+++ b/apps/bot/src/discord/utils/index.ts
@@ -6,6 +6,7 @@ export { buildPaginationButtons } from './build-pagination-buttons.js';
 export { getQuery } from './get-query.js';
 export { getTargetUser } from './get-target-user.js';
 export { splitIntoPages, clampPage } from './paginate.js';
+export { parseBigintArg } from './parse-bigint-arg.js';
 export { parseIntegerArg } from './parse-integer-arg.js';
 export { assertInteractorIsTheOwner } from './assert-interactor-is-the-owner.js';
 export { parseOwnerDiscordId } from './parse-owner-discord-id.js';

--- a/apps/bot/src/discord/utils/parse-bigint-arg.ts
+++ b/apps/bot/src/discord/utils/parse-bigint-arg.ts
@@ -1,0 +1,13 @@
+import { ValidationError } from '../errors.js';
+
+export function parseBigintArg(raw: string | undefined): bigint {
+  if (raw === undefined || raw === '') {
+    throw new ValidationError(`"${raw}" n'est pas un nombre entier !`);
+  }
+
+  try {
+    return BigInt(raw);
+  } catch {
+    throw new ValidationError(`"${raw}" n'est pas un nombre entier !`);
+  }
+}

--- a/apps/bot/src/domains/event/constants.ts
+++ b/apps/bot/src/domains/event/constants.ts
@@ -1,3 +1,6 @@
+export const EVENT_BUTTON_NAME = 'evt';
+
+// TODO: ENLEVER CA, CETAIT A LANCIENNE
 export const EVENT_TYPES = {
   BARREL_FOUND: 'barrel_found',
   ISLAND_FOUND: 'island_found',

--- a/apps/bot/src/domains/event/index.ts
+++ b/apps/bot/src/domains/event/index.ts
@@ -1,2 +1,2 @@
-export { eventButtonHandlers } from './interactions/index.js';
+export { eventButtonHandlers } from './interactions/registry.js';
 export { getPendingEventsForPlayer, type PendingEventInstance } from './repository.js';

--- a/apps/bot/src/domains/event/interactions/event-choice-button.ts
+++ b/apps/bot/src/domains/event/interactions/event-choice-button.ts
@@ -1,0 +1,44 @@
+import type { ButtonInteraction } from 'discord.js';
+
+import { InternalError, NotFoundError } from '../../../discord/errors.js';
+import type { ButtonHandler } from '../../../discord/types.js';
+import { parseBigintArg } from '../../../discord/utils/index.js';
+import { EVENT_BUTTON_NAME } from '../constants.js';
+import { allGenerators } from '../generators/registry.js';
+import * as eventRepository from '../repository.js';
+
+export const eventChoiceButtonHandler: ButtonHandler = {
+  name: EVENT_BUTTON_NAME,
+  async handle(interaction: ButtonInteraction, args: Array<string>): Promise<void> {
+    await interaction.deferUpdate();
+
+    const eventInstanceId = parseBigintArg(args[0]);
+
+    const instance = await eventRepository.findById(eventInstanceId);
+    if (!instance) {
+      await interaction.followUp({ content: "Trop tard, l'évènement a déjà été résolu.", ephemeral: true });
+      return;
+    }
+
+    const generator = allGenerators.find((eventGenerator) => eventGenerator.key === instance.eventKey);
+    if (!generator) {
+      throw new NotFoundError(`L'évènement est introuvable (${instance.eventKey})`);
+    }
+
+    if (!generator.isInteractive) {
+      await eventRepository.deleteById(instance.id);
+      // TODO: afficher l'évènement suivant de la queue (cf #192 commande !recap)
+      await interaction.followUp({ content: 'TODO: afficher le prochain évènement.', ephemeral: true });
+      return;
+    }
+
+    const choiceId = args[1];
+    if (!choiceId) {
+      throw new InternalError(`choice_id manquant pour évènement interactif: ${interaction.customId}`);
+    }
+
+    // TODO: brancher le dispatch interactif (resolve / goTo) quand le premier générateur interactif arrive (cf #198).
+    void choiceId;
+    await interaction.followUp({ content: 'TODO: dispatch interactif à brancher.', ephemeral: true });
+  },
+};

--- a/apps/bot/src/domains/event/interactions/index.ts
+++ b/apps/bot/src/domains/event/interactions/index.ts
@@ -1,5 +1,0 @@
-import type { ButtonHandler } from '../../../discord/types.js';
-
-import { recapShortcutButtonHandler } from './recap-shortcut-button.js';
-
-export const eventButtonHandlers: Array<ButtonHandler> = [recapShortcutButtonHandler];

--- a/apps/bot/src/domains/event/interactions/registry.ts
+++ b/apps/bot/src/domains/event/interactions/registry.ts
@@ -1,0 +1,6 @@
+import type { ButtonHandler } from '../../../discord/types.js';
+
+import { eventChoiceButtonHandler } from './event-choice-button.js';
+import { recapShortcutButtonHandler } from './recap-shortcut-button.js';
+
+export const eventButtonHandlers: Array<ButtonHandler> = [recapShortcutButtonHandler, eventChoiceButtonHandler];

--- a/apps/bot/src/domains/event/repository.ts
+++ b/apps/bot/src/domains/event/repository.ts
@@ -26,6 +26,11 @@ export async function updateState(id: bigint, state: JSONFromSQL): Promise<void>
   await db.update(eventInstance).set({ state }).where(eq(eventInstance.id, id));
 }
 
+export async function findById(id: bigint): Promise<EventInstance | null> {
+  const [row] = await db.select().from(eventInstance).where(eq(eventInstance.id, id)).limit(1);
+  return row ?? null;
+}
+
 export async function findFirstInteractivePending(playerId: number): Promise<EventInstance | null> {
   const [row] = await db
     .select()

--- a/apps/bot/src/domains/event/utils/build-event-custom-id.ts
+++ b/apps/bot/src/domains/event/utils/build-event-custom-id.ts
@@ -1,0 +1,12 @@
+import { buildCustomId } from '../../../discord/utils/index.js';
+import { EVENT_BUTTON_NAME } from '../constants.js';
+
+/** @return evt:230212 */
+export function buildPassiveNextCustomId(eventInstanceId: bigint): string {
+  return buildCustomId(EVENT_BUTTON_NAME, eventInstanceId.toString());
+}
+
+/** @return evt:230213:attackCrocodile */
+export function buildInteractiveChoiceCustomId(eventInstanceId: bigint, choiceId: string): string {
+  return buildCustomId(EVENT_BUTTON_NAME, eventInstanceId.toString(), choiceId);
+}


### PR DESCRIPTION
## Résumé
- Ajoute le `ButtonHandler` `evt` (closes #191) qui dispatch les clics sur les boutons d'évènements, pour un passif le marque comme lu (le supprime), pour un interactif : editera avec le choix, et si résolu le supprime
- 
- Format de `custom_id` compact pour rester sous la limite Discord 100 chars : `evt:<id>` pour les passifs (juste « Suivant »), `evt:<id>:<choice_id>` pour les interactifs. Builders dédiés : `buildPassiveNextCustomId` / `buildInteractiveChoiceCustomId`.
- `findById(id)` ajouté au repository `event_instance` pour charger la ligne au clic.
- `parseBigintArg` ajouté à `discord/utils`, symétrique à `parseIntegerArg`
- Réorganisation : `recap-shortcut-button.ts` déplacé sous `event/interactions/`, l'array de handlers vit maintenant dans `interactions/registry.ts`.
