### PR TITLE
Implement replayable bucket synchronization system

### DIFF
--- a/apps/bot/src/domains/character/repository.ts
+++ b/apps/bot/src/domains/character/repository.ts
@@ -14,8 +14,8 @@ import { InternalError, NotFoundError } from '../../discord/errors.js';
 
 import type { CharacterRow, CharacterTemplateInfo } from './types.js';
 
-export async function getCharactersByPlayerId(playerId: number): Promise<Array<CharacterRow>> {
-  return db
+export async function getCharactersByPlayerId(playerId: number, client: DbOrTransaction = db): Promise<Array<CharacterRow>> {
+  return client
     .select({
       instanceId: characterInstance.id,
       name: characterTemplate.name,

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -9,10 +9,11 @@ import * as playerRepository from '../player/repository.js';
 
 import { MAX_CREW_NAME_LENGTH, MIN_CREW_NAME_LENGTH } from './constants.js';
 import * as crewRepository from './repository.js';
+import { isInCrewFilter } from './utils/is-in-crew-filter.js';
 
 export async function getCrewByPlayerId(playerId: number): Promise<Array<CharacterRow>> {
   const characters = await characterRepository.getCharactersByPlayerId(playerId);
-  const crew = characters.filter((character) => character.joinedCrewAt !== null);
+  const crew = characters.filter(isInCrewFilter);
 
   if (crew.length === 0) {
     throw new NotFoundError("Tu n'as aucun personnage dans ton équipage.");

--- a/apps/bot/src/domains/crew/utils/is-in-crew-filter.ts
+++ b/apps/bot/src/domains/crew/utils/is-in-crew-filter.ts
@@ -1,0 +1,5 @@
+import type { CharacterRow } from '../../character/types.js';
+
+export function isInCrewFilter(character: CharacterRow): boolean {
+  return character.joinedCrewAt !== null;
+}

--- a/apps/bot/src/domains/event/effects/apply-effects.ts
+++ b/apps/bot/src/domains/event/effects/apply-effects.ts
@@ -1,17 +1,24 @@
 import { type DbOrTransaction } from '@one-piece/db';
 
 import * as economyRepository from '../../economy/repository.js';
+import type { GeneratorContext } from '../types.js';
 
 import type { EventEffect } from './types.js';
 
-export async function applyEffects(effects: Array<EventEffect>, playerId: number, tx: DbOrTransaction): Promise<void> {
+/**
+ * Applique les effets en DB **et** mute `ctx` en place pour que les générateurs
+ * suivants (même bucket ou buckets ultérieurs) voient l'état à jour sans refetch.
+ */
+export async function applyEffects(effects: Array<EventEffect>, ctx: GeneratorContext, tx: DbOrTransaction): Promise<void> {
   for (const effect of effects) {
     switch (effect.type) {
       case 'addBerries':
-        await economyRepository.creditBerry(playerId, effect.amount, tx);
+        await economyRepository.creditBerry(ctx.player.id, effect.amount, tx);
+        ctx.player.berries += effect.amount;
         break;
       case 'spendBerries':
-        await economyRepository.debitBerry(playerId, effect.amount, tx);
+        await economyRepository.debitBerry(ctx.player.id, effect.amount, tx);
+        ctx.player.berries -= effect.amount;
         break;
     }
   }

--- a/apps/bot/src/domains/event/engine/bucket.ts
+++ b/apps/bot/src/domains/event/engine/bucket.ts
@@ -1,13 +1,18 @@
 export const BUCKET_DURATION_SEC = 15 * 60;
 
-export function bucketIdFromTimestamp(date: Date): number {
+export function getBucketIdFromDate(date: Date): number {
   return Math.floor(date.getTime() / 1000 / BUCKET_DURATION_SEC);
 }
 
-export function startOfBucket(bucketId: number): Date {
+export function getStartDateOfBucket(bucketId: number): Date {
   return new Date(bucketId * BUCKET_DURATION_SEC * 1000);
 }
 
-export function endOfBucket(bucketId: number): Date {
+export function getEndDateOfBucket(bucketId: number): Date {
   return new Date((bucketId + 1) * BUCKET_DURATION_SEC * 1000);
+}
+
+/** Dernier bucket complet (= courant - 1). Le bucket en cours n'est pas traité tant qu'il n'est pas terminé. */
+export function getLatestProcessableBucket(): number {
+  return getBucketIdFromDate(new Date()) - 1;
 }

--- a/apps/bot/src/domains/event/engine/clamp-replay-window.ts
+++ b/apps/bot/src/domains/event/engine/clamp-replay-window.ts
@@ -1,0 +1,12 @@
+import { BUCKET_DURATION_SEC } from './bucket.js';
+
+const MAX_HOURS_TO_REPLAY = 48;
+const MAX_BUCKETS_TO_REPLAY = (MAX_HOURS_TO_REPLAY * 60 * 60) / BUCKET_DURATION_SEC;
+
+/**
+ * Borne le bucket de départ à la fenêtre de replay MAX_HOURS_TO_REPLAY (48h max).
+ * Si le joueur est AFK depuis plus longtemps, les buckets en dehors de la fenêtre sont silencieusement perdus.
+ */
+export function clampToReplayWindow(fromBucket: number, latestProcessableBucket: number): number {
+  return Math.max(fromBucket, latestProcessableBucket - MAX_BUCKETS_TO_REPLAY + 1);
+}

--- a/apps/bot/src/domains/event/engine/context-builders.ts
+++ b/apps/bot/src/domains/event/engine/context-builders.ts
@@ -1,0 +1,28 @@
+import type { CharacterRow } from '../../character/types.js';
+import type { HistoryEntry } from '../../history/repository.js';
+import type { GeneratorContext } from '../types.js';
+
+// TODO: renommer le champ `eventType` → `kind` quand history.event_type sera renommé (cf packages/db/src/domains/history/schema.ts)
+export type HistoryRow = Pick<HistoryEntry, 'eventType' | 'bucketId'>;
+
+export function buildCrewAccessor(members: Array<CharacterRow>): GeneratorContext['crew'] {
+  function find(name: string): CharacterRow | undefined {
+    return members.find((m) => m.name === name || m.nickname === name);
+  }
+  return {
+    members,
+    has: (name) => find(name) !== undefined,
+    getByName: (name) => find(name),
+  };
+}
+
+export function buildHistoryAccessor(historyLogs: Array<HistoryRow>, getCurrentBucketId: () => number): GeneratorContext['history'] {
+  return {
+    has: (type) => historyLogs.some((log) => log.eventType === type),
+    lastResolutionOf: (prefix) => historyLogs.findLast((log) => log.eventType.startsWith(prefix))?.eventType,
+    countSinceNBuckets: (type, nBuckets) => {
+      const minBucket = getCurrentBucketId() - nBuckets;
+      return historyLogs.filter((log) => log.eventType === type && log.bucketId !== null && log.bucketId > minBucket).length;
+    },
+  };
+}

--- a/apps/bot/src/domains/event/engine/evaluate-generator-happening.ts
+++ b/apps/bot/src/domains/event/engine/evaluate-generator-happening.ts
@@ -1,0 +1,19 @@
+import type { EventGenerator, GeneratorContext, Rng } from '../types.js';
+
+import { createRng, seedFromBucketAndPlayer, seedFromBucketAndZone } from './rng.js';
+
+/**
+ * Évalue les filtres (conditions, cooldown, oneTime) puis tire la probabilité.
+ * @returns le rng (déjà avancé d'un tick par le test de proba) si le générateur passe, sinon return null
+ */
+export function evaluateGeneratorHappening(gen: EventGenerator, ctx: GeneratorContext, playerId: number): Rng | null {
+  if (gen.conditions && !gen.conditions(ctx)) return null;
+  if (gen.cooldownBuckets !== undefined && ctx.history.countSinceNBuckets(gen.key, gen.cooldownBuckets) > 0) return null;
+  if (gen.oneTime === true && ctx.history.has(gen.key)) return null;
+
+  const seed = gen.seedScope === 'zone' ? seedFromBucketAndZone(ctx.bucketId, ctx.zone) : seedFromBucketAndPlayer(ctx.bucketId, playerId);
+  const rng = createRng(seed);
+
+  if (rng.next() >= gen.probability(ctx)) return null;
+  return rng;
+}

--- a/apps/bot/src/domains/event/engine/rng.ts
+++ b/apps/bot/src/domains/event/engine/rng.ts
@@ -62,3 +62,9 @@ export function createRng(seed: number): Rng {
     },
   };
 }
+
+/** Tirage déterministe d'un élément à partir d'une graine. Équivalent seeded de `lodash.sample`. */
+export function pickRandomWithSeed<T>(seed: number, items: Array<T>): T {
+  if (items.length === 0) throw new Error('pickRandomWithSeed: items is empty');
+  return items[Math.floor(createRng(seed).next() * items.length)]!;
+}

--- a/apps/bot/src/domains/event/engine/synchronize-player.ts
+++ b/apps/bot/src/domains/event/engine/synchronize-player.ts
@@ -1,0 +1,106 @@
+import { db } from '@one-piece/db';
+
+import * as characterRepository from '../../character/repository.js';
+import { isInCrewFilter } from '../../crew/utils/is-in-crew-filter.js';
+import * as historyRepository from '../../history/index.js';
+import * as playerRepository from '../../player/repository.js';
+import * as resourceRepository from '../../resource/repository.js';
+import * as shipRepository from '../../ship/repository.js';
+import { applyEffects } from '../effects/apply-effects.js';
+import { interactiveGenerators, passiveGenerators } from '../generators/registry.js';
+import * as eventRepository from '../repository.js';
+import type { GeneratorContext, InteractiveGenerator } from '../types.js';
+
+import { getLatestProcessableBucket } from './bucket.js';
+import { clampToReplayWindow } from './clamp-replay-window.js';
+import { buildCrewAccessor, buildHistoryAccessor, type HistoryRow } from './context-builders.js';
+import { evaluateGeneratorHappening } from './evaluate-generator-happening.js';
+import { pickRandomWithSeed, seedFromBucketAndPlayer } from './rng.js';
+
+export type SyncResult =
+  | { kind: 'already_caught_up' }
+  | { kind: 'caught_up'; generatedPassiveCount: number }
+  | { kind: 'blocked_on_interactive'; generatedPassiveCount: number; interactiveKey: string };
+
+export async function synchronizePlayer(playerId: number): Promise<SyncResult> {
+  return db.transaction(async (tx) => {
+    const player = await playerRepository.findByIdOrThrow(playerId, tx, { forUpdate: true });
+
+    const interactivePending = await eventRepository.findFirstInteractivePending(playerId, tx);
+    if (interactivePending) {
+      return { kind: 'blocked_on_interactive', generatedPassiveCount: 0, interactiveKey: interactivePending.eventKey };
+    }
+
+    const latestProcessableBucket = getLatestProcessableBucket();
+    let fromBucket = player.lastProcessedBucketId + 1;
+    if (fromBucket > latestProcessableBucket) {
+      return { kind: 'already_caught_up' };
+    }
+    fromBucket = clampToReplayWindow(fromBucket, latestProcessableBucket);
+
+    const ship = await shipRepository.findByPlayerIdOrThrow(playerId, tx);
+    const inventory = await resourceRepository.getInventory(playerId, tx);
+    const allCharacters = await characterRepository.getCharactersByPlayerId(playerId, tx);
+    const historyLogsLoaded = await historyRepository.loadAllForPlayer(playerId, tx);
+
+    const crew = buildCrewAccessor(allCharacters.filter(isInCrewFilter));
+    const historyLogs: Array<HistoryRow> = [...historyLogsLoaded];
+
+    let generatedPassiveCount = 0;
+    let currentBucket = fromBucket;
+    const history = buildHistoryAccessor(historyLogs, () => currentBucket);
+
+    for (let bucketId = fromBucket; bucketId <= latestProcessableBucket; bucketId++) {
+      currentBucket = bucketId;
+
+      const ctx: GeneratorContext = {
+        player,
+        crew,
+        ship,
+        inventory,
+        history,
+        bucketId,
+        // TODO: navigation — quand la zone pourra changer en cours de replay (générateur `travel.arrival`
+        // qui émet un effect `changeZone`, ou interactif "Partir" qui passe par applyEffects), la mutation
+        // in-place de ctx.player.currentZone par applyEffects suffira. En attendant, la zone est constante.
+        zone: player.currentZone,
+        // TODO: cross-player v2 — remplir avec les autres joueurs présents dans la zone à ce bucket
+        othersInZone: [],
+      };
+
+      for (const gen of passiveGenerators) {
+        const rng = evaluateGeneratorHappening(gen, ctx, playerId);
+        if (!rng) continue;
+
+        const { effects, state } = gen.compute(ctx, rng);
+
+        await applyEffects(effects, ctx, tx);
+        await eventRepository.insertWithIdempotence({ playerId, eventKey: gen.key, isInteractive: false, bucketId, state }, tx);
+        await historyRepository.writeEventResolution({ actorPlayerId: playerId, eventType: gen.key, bucketId }, tx);
+
+        generatedPassiveCount++;
+        // Mutation in-place : les buckets suivants doivent voir les events qu'on vient de générer (cooldown / oneTime / has).
+        historyLogs.push({ eventType: gen.key, bucketId });
+      }
+
+      const candidates: Array<InteractiveGenerator> = [];
+      for (const gen of interactiveGenerators) {
+        if (evaluateGeneratorHappening(gen, ctx, playerId)) candidates.push(gen);
+      }
+
+      if (candidates.length > 0) {
+        const picked = pickRandomWithSeed(seedFromBucketAndPlayer(bucketId, playerId), candidates);
+
+        await eventRepository.insertWithIdempotence(
+          { playerId, eventKey: picked.key, isInteractive: true, bucketId, state: { step: picked.initial } },
+          tx,
+        );
+        await playerRepository.setLastProcessedBucketId(playerId, bucketId, tx);
+        return { kind: 'blocked_on_interactive', generatedPassiveCount, interactiveKey: picked.key };
+      }
+    }
+
+    await playerRepository.setLastProcessedBucketId(playerId, latestProcessableBucket, tx);
+    return { kind: 'caught_up', generatedPassiveCount };
+  });
+}

--- a/apps/bot/src/domains/event/engine/validate-generators-paths.ts
+++ b/apps/bot/src/domains/event/engine/validate-generators-paths.ts
@@ -16,7 +16,7 @@ const fakeCtx: GeneratorContext = {
   history: {
     has: () => false,
     lastResolutionOf: () => undefined,
-    countSinceBuckets: () => 0,
+    countSinceNBuckets: () => 0,
   },
   bucketId: 0,
   zone: 'sea_east_blue' as Zone,

--- a/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
+++ b/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
@@ -7,7 +7,9 @@ export const seagullFlyby: PassiveGenerator = {
   key: 'passive.seagull_flyby',
   isInteractive: false,
   seedScope: 'player',
-  conditions: (ctx) => ctx.zone === 'sea_east_blue',
+  conditions: (ctx) => {
+    return ctx.zone === 'sea_east_blue';
+  },
   cooldownBuckets: 2,
   probability: () => 0.3,
 

--- a/apps/bot/src/domains/event/repository.ts
+++ b/apps/bot/src/domains/event/repository.ts
@@ -1,4 +1,4 @@
-import { db, eventInstance, type EventInstance, type JSONFromSQL } from '@one-piece/db';
+import { db, eventInstance, type DbOrTransaction, type EventInstance, type JSONFromSQL } from '@one-piece/db';
 import { asc, eq, and } from 'drizzle-orm';
 
 export type PendingEventInstance = Omit<EventInstance, 'playerId' | 'state'> & {
@@ -31,8 +31,8 @@ export async function findById(id: bigint): Promise<EventInstance | null> {
   return row ?? null;
 }
 
-export async function findFirstInteractivePending(playerId: number): Promise<EventInstance | null> {
-  const [row] = await db
+export async function findFirstInteractivePending(playerId: number, client: DbOrTransaction = db): Promise<EventInstance | null> {
+  const [row] = await client
     .select()
     .from(eventInstance)
     .where(and(eq(eventInstance.playerId, playerId), eq(eventInstance.isInteractive, true)))
@@ -47,4 +47,19 @@ export async function findFirstInteractivePending(playerId: number): Promise<Eve
 export async function deleteById(id: bigint): Promise<{ deleted: boolean }> {
   const rows = await db.delete(eventInstance).where(eq(eventInstance.id, id)).returning({ id: eventInstance.id });
   return { deleted: rows.length > 0 };
+}
+
+type InsertWithIdempotenceArgs = {
+  playerId: number;
+  eventKey: string;
+  isInteractive: boolean;
+  bucketId: number;
+  state: JSONFromSQL;
+};
+
+export async function insertWithIdempotence(args: InsertWithIdempotenceArgs, client: DbOrTransaction = db): Promise<void> {
+  await client
+    .insert(eventInstance)
+    .values(args)
+    .onConflictDoNothing({ target: [eventInstance.playerId, eventInstance.eventKey, eventInstance.bucketId] });
 }

--- a/apps/bot/src/domains/event/types.ts
+++ b/apps/bot/src/domains/event/types.ts
@@ -22,7 +22,7 @@ export type GeneratorContext = {
   history: {
     has: (type: string) => boolean;
     lastResolutionOf: (prefix: string) => string | undefined;
-    countSinceBuckets: (type: string, buckets: number) => number;
+    countSinceNBuckets: (type: string, bucketsAgo: number) => number;
   };
   bucketId: number;
   zone: Zone;

--- a/apps/bot/src/domains/history/index.ts
+++ b/apps/bot/src/domains/history/index.ts
@@ -1,1 +1,1 @@
-export { appendHistory, loadAllForPlayer } from './repository.js';
+export { appendHistory, loadAllForPlayer, writeEventResolution } from './repository.js';

--- a/apps/bot/src/domains/history/repository.ts
+++ b/apps/bot/src/domains/history/repository.ts
@@ -1,5 +1,5 @@
 import { db, history, type DbOrTransaction, type JSONFromSQL } from '@one-piece/db';
-import { asc, eq } from 'drizzle-orm';
+import { asc, eq, sql } from 'drizzle-orm';
 
 import type { HistoryTarget } from './types/common.js';
 import type { Log } from './types/index.js';
@@ -32,15 +32,15 @@ export async function appendHistory({
   });
 }
 
-type HistoryEntry = {
+export type HistoryEntry = {
   eventType: string;
   occurredAt: Date;
   bucketId: number | null;
   payload: JSONFromSQL;
 };
 
-export async function loadAllForPlayer(playerId: number): Promise<Array<HistoryEntry>> {
-  return db
+export async function loadAllForPlayer(playerId: number, client: DbOrTransaction = db): Promise<Array<HistoryEntry>> {
+  return client
     .select({
       eventType: history.eventType,
       occurredAt: history.occurredAt,
@@ -50,4 +50,21 @@ export async function loadAllForPlayer(playerId: number): Promise<Array<HistoryE
     .from(history)
     .where(eq(history.actorPlayerId, playerId))
     .orderBy(asc(history.occurredAt));
+}
+
+type WriteEventResolutionArgs = {
+  actorPlayerId: number;
+  // TODO: renommer en `kind` quand history.event_type sera renommé (cf packages/db/src/domains/history/schema.ts)
+  eventType: string;
+  bucketId: number;
+};
+
+export async function writeEventResolution(args: WriteEventResolutionArgs, client: DbOrTransaction = db): Promise<void> {
+  await client
+    .insert(history)
+    .values(args)
+    .onConflictDoNothing({
+      target: [history.actorPlayerId, history.eventType, history.bucketId],
+      where: sql`${history.actorPlayerId} IS NOT NULL AND ${history.bucketId} IS NOT NULL`,
+    });
 }

--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -3,13 +3,22 @@ import { eq } from 'drizzle-orm';
 
 import { NotFoundError } from '../../discord/errors.js';
 
-export async function findById(id: number, client: DbOrTransaction = db): Promise<Player | undefined> {
+type FindByIdOptions = {
+  forUpdate?: boolean;
+};
+
+export async function findById(id: number, client: DbOrTransaction = db, options: FindByIdOptions = {}): Promise<Player | undefined> {
+  if (options.forUpdate) {
+    const [row] = await client.select().from(player).where(eq(player.id, id)).limit(1).for('update');
+    return row;
+  }
+
   const [row] = await client.select().from(player).where(eq(player.id, id)).limit(1);
   return row;
 }
 
-export async function findByIdOrThrow(id: number, client: DbOrTransaction = db): Promise<Player> {
-  const row = await findById(id, client);
+export async function findByIdOrThrow(id: number, client: DbOrTransaction = db, options: FindByIdOptions = {}): Promise<Player> {
+  const row = await findById(id, client, options);
   if (!row) throw new NotFoundError('Joueur introuvable.');
   return row;
 }

--- a/docs/domains/event/generators.md
+++ b/docs/domains/event/generators.md
@@ -205,16 +205,16 @@ Pas un gros event "Alabasta". Une **suite d'events distincts** qui se débloquen
 
 ## `ctx` : objet contexte
 
-| Champ              | Contenu                                                                               |
-| ------------------ | ------------------------------------------------------------------------------------- |
-| `ctx.player`       | ligne `player` actuelle                                                               |
-| `ctx.crew`         | `members: Array<CharacterRow>` + helpers `has(name)`, `getByName(name)`               |
-| `ctx.ship`         | navire et modules                                                                     |
-| `ctx.inventory`    | ressources                                                                            |
-| `ctx.history`      | helpers : `has(type)`, `lastResolutionOf(prefix)`, `countSinceBuckets(type, buckets)` |
-| `ctx.bucketId`     | bucket en cours                                                                       |
-| `ctx.zone`         | zone du joueur à ce bucket                                                            |
-| `ctx.othersInZone` | autres joueurs présents dans la zone au bucket (tous serveurs confondus)              |
+| Champ              | Contenu                                                                                   |
+| ------------------ | ----------------------------------------------------------------------------------------- |
+| `ctx.player`       | ligne `player` actuelle                                                                   |
+| `ctx.crew`         | `members: Array<CharacterRow>` + helpers `has(name)`, `getByName(name)`                   |
+| `ctx.ship`         | navire et modules                                                                         |
+| `ctx.inventory`    | ressources                                                                                |
+| `ctx.history`      | helpers : `has(type)`, `lastResolutionOf(prefix)`, `countSinceNBuckets(type, bucketsAgo)` |
+| `ctx.bucketId`     | bucket en cours                                                                           |
+| `ctx.zone`         | zone du joueur à ce bucket                                                                |
+| `ctx.othersInZone` | autres joueurs présents dans la zone au bucket (tous serveurs confondus)                  |
 
 > **Pourquoi un objet plutôt que des paramètres positionnels** : ajouter `ctx.weather` ne casse aucun générateur existant.
 
@@ -234,7 +234,7 @@ type EventEffect =
 
 > **État courant** : seuls `addBerries` et `spendBerries` sont implémentés (cf `apps/bot/src/domains/event/effects/types.ts`). Le reste est roadmap.
 
-L'engine a `applyEffects(effects, playerId, tx)` qui dispatch chaque variante.
+L'engine a `applyEffects(effects, ctx, tx)` qui dispatch chaque variante. Chaque effet **persiste** la modification en DB **et** mute `ctx` en place (ex: `ctx.player.berries += amount`) pour que les générateurs suivants voient l'état à jour sans refetch.
 
 > **Pourquoi pas `ctx.player.berries += 50` dans `resolve`** : couple le générateur à Drizzle / aux transactions, disperse le code (impossible de retrouver tous les effets sur les berries), difficile à tester. Avec Effects en data : pure logique métier d'un côté, persistance de l'autre.
 

--- a/docs/domains/event/performance.md
+++ b/docs/domains/event/performance.md
@@ -18,8 +18,8 @@ const playerHistory = await client.select().from(history).where(eq(history.actor
 ctx.history = {
   has: (type) => playerHistory.some((e) => e.eventType === type),
   lastResolutionOf: (prefix) => playerHistory.filter((e) => e.eventType.startsWith(prefix)).at(-1)?.eventType,
-  countSinceBuckets: (type, buckets) =>
-    playerHistory.filter((e) => e.eventType === type && e.bucketId !== null && e.bucketId > currentBucket - buckets).length,
+  countSinceNBuckets: (type, bucketsAgo) =>
+    playerHistory.filter((e) => e.eventType === type && e.bucketId !== null && e.bucketId > currentBucket - bucketsAgo).length,
 };
 ```
 

--- a/packages/db/drizzle/0033_history_actor_event_bucket_uniq.sql
+++ b/packages/db/drizzle/0033_history_actor_event_bucket_uniq.sql
@@ -1,0 +1,1 @@
+CREATE UNIQUE INDEX "history_actor_event_bucket_uniq" ON "history" USING btree ("actor_player_id","event_type","bucket_id") WHERE "history"."actor_player_id" IS NOT NULL AND "history"."bucket_id" IS NOT NULL;

--- a/packages/db/drizzle/meta/0033_snapshot.json
+++ b/packages/db/drizzle/meta/0033_snapshot.json
@@ -1,0 +1,1322 @@
+{
+  "id": "428dfca7-517c-4c54-8ac9-72e6efc90cb6",
+  "prevId": "f9434bad-8bb1-413f-af3e-5e5e49e2933b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.character_instance": {
+      "name": "character_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_crew_at": {
+          "name": "joined_crew_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_captain": {
+          "name": "is_captain",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "devil_fruit_template_id": {
+          "name": "devil_fruit_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_instance_player_template_uniq": {
+          "name": "character_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "character_instance_one_captain_per_player": {
+          "name": "character_instance_one_captain_per_player",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"character_instance\".\"is_captain\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_instance_template_id_character_template_id_fk": {
+          "name": "character_instance_template_id_character_template_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "character_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "character_instance_player_id_player_id_fk": {
+          "name": "character_instance_player_id_player_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "character_instance_devil_fruit_template_id_devil_fruit_template_id_fk": {
+          "name": "character_instance_devil_fruit_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "character_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "devil_fruit_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "character_instance_captain_must_be_in_crew": {
+          "name": "character_instance_captain_must_be_in_crew",
+          "value": "NOT \"character_instance\".\"is_captain\" OR \"character_instance\".\"joined_crew_at\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.character_template": {
+      "name": "character_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "combat": {
+          "name": "combat",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "devil_fruit_template_id": {
+          "name": "devil_fruit_template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "race": {
+          "name": "race",
+          "type": "character_race",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "character_template_name_trgm_idx": {
+          "name": "character_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "character_template_devil_fruit_template_id_devil_fruit_template_id_fk": {
+          "name": "character_template_devil_fruit_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "character_template",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "devil_fruit_template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "character_template_name_unique": {
+          "name": "character_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_instance": {
+      "name": "devil_fruit_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_instance_player_template_uniq": {
+          "name": "devil_fruit_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devil_fruit_instance_template_id_devil_fruit_template_id_fk": {
+          "name": "devil_fruit_instance_template_id_devil_fruit_template_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "devil_fruit_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "devil_fruit_instance_player_id_player_id_fk": {
+          "name": "devil_fruit_instance_player_id_player_id_fk",
+          "tableFrom": "devil_fruit_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devil_fruit_template": {
+      "name": "devil_fruit_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "types": {
+          "name": "types",
+          "type": "devil_fruit_type[]",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::devil_fruit_type[]"
+        },
+        "hp_bonus": {
+          "name": "hp_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "combat_bonus": {
+          "name": "combat_bonus",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devil_fruit_template_name_trgm_idx": {
+          "name": "devil_fruit_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "devil_fruit_template_name_unique": {
+          "name": "devil_fruit_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_instance": {
+      "name": "event_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_key": {
+          "name": "event_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_interactive": {
+          "name": "is_interactive",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "state": {
+          "name": "state",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "event_instance_player_event_key_bucket_uniq": {
+          "name": "event_instance_player_event_key_bucket_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_instance_player_id_player_id_fk": {
+          "name": "event_instance_player_id_player_id_fk",
+          "tableFrom": "event_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.guild": {
+      "name": "guild",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(32)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'fr'"
+        },
+        "prefix": {
+          "name": "prefix",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'!'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.history": {
+      "name": "history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "bucket_id": {
+          "name": "bucket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_player_id": {
+          "name": "actor_player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_id": {
+          "name": "target_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        }
+      },
+      "indexes": {
+        "history_occurred_at_idx": {
+          "name": "history_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_event_type_occurred_at_idx": {
+          "name": "history_event_type_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_actor_player_id_occurred_at_idx": {
+          "name": "history_actor_player_id_occurred_at_idx",
+          "columns": [
+            {
+              "expression": "actor_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"history\".\"actor_player_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_target_idx": {
+          "name": "history_target_idx",
+          "columns": [
+            {
+              "expression": "target_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"history\".\"target_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "history_actor_event_bucket_uniq": {
+          "name": "history_actor_event_bucket_uniq",
+          "columns": [
+            {
+              "expression": "actor_player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "bucket_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"history\".\"actor_player_id\" IS NOT NULL AND \"history\".\"bucket_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "history_actor_player_id_player_id_fk": {
+          "name": "history_actor_player_id_player_id_fk",
+          "tableFrom": "history",
+          "tableTo": "player",
+          "columnsFrom": [
+            "actor_player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player": {
+      "name": "player",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin_guild_id": {
+          "name": "origin_guild_id",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "karma": {
+          "name": "karma",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "crew_name": {
+          "name": "crew_name",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bounty": {
+          "name": "bounty",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "berries": {
+          "name": "berries",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "0"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_processed_bucket_id": {
+          "name": "last_processed_bucket_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_admin": {
+          "name": "is_admin",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_zone": {
+          "name": "current_zone",
+          "type": "zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'foosha'"
+        },
+        "travel_target_zone": {
+          "name": "travel_target_zone",
+          "type": "zone",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_started_bucket": {
+          "name": "travel_started_bucket",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "travel_eta_bucket": {
+          "name": "travel_eta_bucket",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_origin_guild_id_guild_id_fk": {
+          "name": "player_origin_guild_id_guild_id_fk",
+          "tableFrom": "player",
+          "tableTo": "guild",
+          "columnsFrom": [
+            "origin_guild_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_discord_id_unique": {
+          "name": "player_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.resource_instance": {
+      "name": "resource_instance",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quantity": {
+          "name": "quantity",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_instance_player_template_uniq": {
+          "name": "resource_instance_player_template_uniq",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "template_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "resource_instance_template_id_resource_template_id_fk": {
+          "name": "resource_instance_template_id_resource_template_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "resource_template",
+          "columnsFrom": [
+            "template_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        },
+        "resource_instance_player_id_player_id_fk": {
+          "name": "resource_instance_player_id_player_id_fk",
+          "tableFrom": "resource_instance",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "resource_instance_quantity_non_negative": {
+          "name": "resource_instance_quantity_non_negative",
+          "value": "\"resource_instance\".\"quantity\" >= 0"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.resource_template": {
+      "name": "resource_template",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rarity": {
+          "name": "rarity",
+          "type": "rarity",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'COMMON'"
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "resource_template_name_trgm_idx": {
+          "name": "resource_template_name_trgm_idx",
+          "columns": [
+            {
+              "expression": "\"name\" gin_trgm_ops",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "gin",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "resource_template_name_unique": {
+          "name": "resource_template_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ship": {
+      "name": "ship",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hp": {
+          "name": "hp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 100
+        },
+        "hull_level": {
+          "name": "hull_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "sail_level": {
+          "name": "sail_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "decks_level": {
+          "name": "decks_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cabins_level": {
+          "name": "cabins_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "cargo_level": {
+          "name": "cargo_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ship_player_id_player_id_fk": {
+          "name": "ship_player_id_player_id_fk",
+          "tableFrom": "ship",
+          "tableTo": "player",
+          "columnsFrom": [
+            "player_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ship_player_id_unique": {
+          "name": "ship_player_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "player_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.character_race": {
+      "name": "character_race",
+      "schema": "public",
+      "values": [
+        "HUMAN",
+        "MINK",
+        "FISHMAN",
+        "GIANT",
+        "LUNARIAN",
+        "SKYPIEAN",
+        "CYBORG",
+        "MERMAID",
+        "DWARF"
+      ]
+    },
+    "public.devil_fruit_type": {
+      "name": "devil_fruit_type",
+      "schema": "public",
+      "values": [
+        "FEU",
+        "GLACE",
+        "MAGMA",
+        "FOUDRE",
+        "TENEBRES",
+        "LUMIERE",
+        "SABLE",
+        "GAZ",
+        "CAOUTCHOUC",
+        "POISON"
+      ]
+    },
+    "public.rarity": {
+      "name": "rarity",
+      "schema": "public",
+      "values": [
+        "COMMON",
+        "RARE",
+        "VERY_RARE",
+        "LEGENDARY"
+      ]
+    },
+    "public.zone": {
+      "name": "zone",
+      "schema": "public",
+      "values": [
+        "foosha",
+        "loguetown",
+        "reverse_mountain",
+        "whisky_peak",
+        "little_garden",
+        "drum",
+        "alabasta",
+        "sea_east_blue",
+        "sea_paradise",
+        "sea_new_world"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1778070909894,
       "tag": "0032_flip_reset_de_sidali",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1778228660492,
+      "tag": "0033_history_actor_event_bucket_uniq",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/domains/history/schema.ts
+++ b/packages/db/src/domains/history/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from 'drizzle-orm';
-import { bigserial, index, integer, jsonb, pgTable, text, timestamp } from 'drizzle-orm/pg-core';
+import { bigserial, index, integer, jsonb, pgTable, text, timestamp, uniqueIndex } from 'drizzle-orm/pg-core';
 
 import type { JSONFromSQL } from '../../shared/types.js';
 import { player } from '../player/schema.js';
@@ -10,6 +10,7 @@ export const history = pgTable(
     id: bigserial('id', { mode: 'bigint' }).primaryKey(),
     bucketId: integer('bucket_id'),
     occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull().defaultNow(),
+    // TODO: renommer `event_type` → `kind` (ambigu avec le domaine `event` qui désigne les events du jeu, cf event_instance)
     eventType: text('event_type').notNull(),
     actorPlayerId: integer('actor_player_id').references(() => player.id, { onDelete: 'set null' }),
     targetType: text('target_type'),
@@ -28,6 +29,9 @@ export const history = pgTable(
     index('history_target_idx')
       .on(table.targetType, table.targetId)
       .where(sql`${table.targetId} IS NOT NULL`),
+    uniqueIndex('history_actor_event_bucket_uniq')
+      .on(table.actorPlayerId, table.eventType, table.bucketId)
+      .where(sql`${table.actorPlayerId} IS NOT NULL AND ${table.bucketId} IS NOT NULL`),
   ],
 );
 


### PR DESCRIPTION
## Résumé
- Ajoute `synchronizePlayer` : moteur de replay solo qui rejoue les buckets manqués depuis `last_processed_bucket_id` (cap 48h), génère les events passifs et bloque sur le premier interactif.
- Atomicité et idempotence : lock `FOR UPDATE` sur le joueur + index unique partiel sur `history(actor, event_type, bucket)` + `onConflictDoNothing` sur `event_instance` et `history` → un retry ou un sync concurrent ne dédoublonne ni les events ni les résolutions.
- Les `effects` mutent `ctx` en place (ex: `ctx.player.berries += amount`) en plus de persister en DB, pour que les générateurs suivants du même bucket voient l'état à jour sans refetch.
- Helpers extraits autour du moteur (`evaluate-generator-happening`, `context-builders`, `clamp-replay-window`, `pickRandomWithSeed`) + doc `generators.md` / `performance.md` mises à jour.
