### PR TITLE
feat(discord): auto-sync joueur avant chaque commande active

### DIFF
--- a/apps/bot/src/discord/errors.ts
+++ b/apps/bot/src/discord/errors.ts
@@ -42,9 +42,9 @@ export class InternalError extends AppError {
   }
 }
 
-export class AdminOnlyError extends AppError {
+export class RequiresAdminError extends ForbiddenError {
   constructor() {
-    super('Cette commande est réservée aux admins.', 'warn');
-    this.name = 'AdminOnlyError';
+    super('Cette commande est réservée aux admins.');
+    this.name = 'RequiresAdminError';
   }
 }

--- a/apps/bot/src/discord/router.ts
+++ b/apps/bot/src/discord/router.ts
@@ -3,6 +3,7 @@ import type { Message } from 'discord.js';
 import { devCommands } from '../domains/_dev/index.js';
 import { infoCommands } from '../domains/_info/index.js';
 import { crewCommands } from '../domains/crew/index.js';
+import { autoSyncBeforeAction } from '../domains/event/index.js';
 import { fishingCommands } from '../domains/fishing/index.js';
 import { requireGuildId } from '../domains/guild/index.js';
 import * as guildRepository from '../domains/guild/repository.js';
@@ -45,11 +46,19 @@ export async function routeMessage(message: Message, prefix: string): Promise<vo
     const guildId = requireGuildId(message.guildId);
     const guild = await guildRepository.findOrCreate(guildId);
     const { player } = await findOrCreatePlayer(message.author.id, message.author.username, guild.id);
+
+    if (command.requiresSynchronization !== false) {
+      await autoSyncBeforeAction(message, player.id);
+    }
+
     await command.handler({ message, args, player, guild });
   } catch (error) {
     if (error instanceof AppError) {
       console[error.severity](error);
-      await message.reply({ embeds: [buildOpEmbed(error.severity).setDescription(error.userMessage)], failIfNotExists: false });
+      await message.reply({
+        ...(error.userView ?? { embeds: [buildOpEmbed(error.severity).setDescription(error.userMessage)] }),
+        failIfNotExists: false,
+      });
     } else {
       console.error(error);
       await message.reply({ embeds: [buildOpEmbed('error').setDescription('Une erreur est survenue.')], failIfNotExists: false });

--- a/apps/bot/src/discord/types.ts
+++ b/apps/bot/src/discord/types.ts
@@ -13,8 +13,8 @@ export type CommandContext = {
 export type Command = {
   name: CommandName;
   handler: (ctx: CommandContext) => Promise<void>;
-  requiresSynchronization?: boolean; // défaut : true (cf #189)
-  adminOnly?: boolean; // défaut : false
+  requiresSynchronization?: boolean;
+  requiresAdmin?: boolean;
 };
 
 export type ButtonHandler = {

--- a/apps/bot/src/domains/_dev/commands/index.ts
+++ b/apps/bot/src/domains/_dev/commands/index.ts
@@ -30,4 +30,4 @@ export const devCommands = [
   sellCommand,
   upgradeShipCommand,
   dmCommand,
-].map((cmd) => ({ ...cmd, adminOnly: true }));
+].map((cmd) => ({ ...cmd, requiresAdmin: true, requiresSynchronization: false }));

--- a/apps/bot/src/domains/_info/commands/index.ts
+++ b/apps/bot/src/domains/_info/commands/index.ts
@@ -2,4 +2,4 @@ import type { Command } from '../../../discord/types.js';
 
 import { infoCommand } from './info.js';
 
-export const infoCommands: Array<Command> = [infoCommand];
+export const infoCommands: Array<Command> = [infoCommand].map((cmd) => ({ ...cmd, requiresSynchronization: false }));

--- a/apps/bot/src/domains/event/auto-sync-before-action.ts
+++ b/apps/bot/src/domains/event/auto-sync-before-action.ts
@@ -1,0 +1,25 @@
+import type { Message } from 'discord.js';
+
+import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+
+import { synchronizePlayer } from './engine/synchronize-player.js';
+import { OutOfSyncError } from './errors.js';
+
+export async function autoSyncBeforeAction(message: Message, playerId: number): Promise<void> {
+  const result = await synchronizePlayer(playerId);
+
+  if (result.status === 'blocked_on_interactive') {
+    throw new OutOfSyncError(message.author.id);
+  }
+
+  if (result.status === 'caught_up' && result.generatedPassiveCount > 0) {
+    await message.reply({
+      embeds: [
+        buildOpEmbed('info').setDescription(
+          // TODO: remplacer par le préfixe de la guild
+          `📜 Ton équipage a vécu ${result.generatedPassiveCount} événement(s). Tape \`!recap\` pour les revivre.`,
+        ),
+      ],
+    });
+  }
+}

--- a/apps/bot/src/domains/event/engine/synchronize-player.ts
+++ b/apps/bot/src/domains/event/engine/synchronize-player.ts
@@ -18,23 +18,27 @@ import { evaluateGeneratorHappening } from './evaluate-generator-happening.js';
 import { pickRandomWithSeed, seedFromBucketAndPlayer } from './rng.js';
 
 export type SyncResult =
-  | { kind: 'already_caught_up' }
-  | { kind: 'caught_up'; generatedPassiveCount: number }
-  | { kind: 'blocked_on_interactive'; generatedPassiveCount: number; interactiveKey: string };
+  | { status: 'already_caught_up' }
+  | { status: 'caught_up'; generatedPassiveCount: number }
+  | { status: 'blocked_on_interactive'; generatedPassiveCount: number; interactiveKey: string };
 
+/**
+ * Rejoue les buckets en attente du joueur (depuis `lastProcessedBucketId`, jusqu'à `lastProcessableBucketId`) :
+ * applique les passives au fur et à mesure, et s'arrête au premier interactif tiré. Le tout en une transaction.
+ */
 export async function synchronizePlayer(playerId: number): Promise<SyncResult> {
   return db.transaction(async (tx) => {
     const player = await playerRepository.findByIdOrThrow(playerId, tx, { forUpdate: true });
 
     const interactivePending = await eventRepository.findFirstInteractivePending(playerId, tx);
     if (interactivePending) {
-      return { kind: 'blocked_on_interactive', generatedPassiveCount: 0, interactiveKey: interactivePending.eventKey };
+      return { status: 'blocked_on_interactive', generatedPassiveCount: 0, interactiveKey: interactivePending.eventKey };
     }
 
     const latestProcessableBucket = getLatestProcessableBucket();
     let fromBucket = player.lastProcessedBucketId + 1;
     if (fromBucket > latestProcessableBucket) {
-      return { kind: 'already_caught_up' };
+      return { status: 'already_caught_up' };
     }
     fromBucket = clampToReplayWindow(fromBucket, latestProcessableBucket);
 
@@ -96,11 +100,11 @@ export async function synchronizePlayer(playerId: number): Promise<SyncResult> {
           tx,
         );
         await playerRepository.setLastProcessedBucketId(playerId, bucketId, tx);
-        return { kind: 'blocked_on_interactive', generatedPassiveCount, interactiveKey: picked.key };
+        return { status: 'blocked_on_interactive', generatedPassiveCount, interactiveKey: picked.key };
       }
     }
 
     await playerRepository.setLastProcessedBucketId(playerId, latestProcessableBucket, tx);
-    return { kind: 'caught_up', generatedPassiveCount };
+    return { status: 'caught_up', generatedPassiveCount };
   });
 }

--- a/apps/bot/src/domains/event/errors.ts
+++ b/apps/bot/src/domains/event/errors.ts
@@ -1,0 +1,22 @@
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+
+import { AppError } from '../../discord/errors.js';
+import { buildCustomId } from '../../discord/utils/build-custom-id.js';
+import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
+
+export class OutOfSyncError extends AppError {
+  constructor(ownerDiscordId: string) {
+    super('Joueur non synchronisé.', 'warn', 'Joueur non synchronisé.', {
+      embeds: [buildOpEmbed('warn').setDescription("Tu as un événement en attente. Vis-le avant d'agir.")],
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setCustomId(buildCustomId('recap-shortcut', ownerDiscordId))
+            .setLabel('Voir mes events')
+            .setStyle(ButtonStyle.Primary),
+        ),
+      ],
+    });
+    this.name = 'OutOfSyncError';
+  }
+}

--- a/apps/bot/src/domains/event/index.ts
+++ b/apps/bot/src/domains/event/index.ts
@@ -1,2 +1,3 @@
+export { autoSyncBeforeAction } from './auto-sync-before-action.js';
 export { eventButtonHandlers } from './interactions/registry.js';
 export { getPendingEventsForPlayer, type PendingEventInstance } from './repository.js';

--- a/apps/bot/src/domains/guild/repository.ts
+++ b/apps/bot/src/domains/guild/repository.ts
@@ -1,6 +1,7 @@
 import { db, guild, type Guild } from '@one-piece/db';
 import { eq } from 'drizzle-orm';
 
+// TODO: MOVE DANS UN SERVICE
 export async function findOrCreate(guildId: string): Promise<Guild> {
   const [existing] = await db.select().from(guild).where(eq(guild.id, guildId)).limit(1);
   if (existing) return existing;

--- a/docs/domains/event/recap-flow.md
+++ b/docs/domains/event/recap-flow.md
@@ -26,23 +26,19 @@ Avec : **le joueur traverse son passé avant d'altérer le présent.** Conséque
 - Pas besoin de `target_effects` dans `history` pour les cross-player : les deux joueurs sont synchros par construction → INSERT direct pour les deux.
 - Pas de fast-forward d'autres joueurs : un joueur observé est forcément à jour à son `last_processed_bucket_id`.
 
-### Implémentation : middleware
+### Implémentation : auto-sync dans le routeur
 
-Appliqué aux commandes "actives" au routeur Discord (toutes sauf `!recap`, `!profil`, `!aide`) :
+Le routeur Discord (`apps/bot/src/discord/router.ts`) appelle `synchronizePlayer(player.id)` avant chaque commande, sauf si la commande opte explicitement out via `requiresSynchronization: false` sur le type `Command` (cas des domaines `_info`, `_dev`, et de la future `!recap`).
 
-```ts
-async function requireSyncedPlayer(playerId, message): Promise<boolean> {
-  if (await playerRepository.isPlayerCaughtUp(playerId)) return true;
-  await message.reply({
-    embeds: [
-      /* "tape !recap d'abord" */
-    ],
-  });
-  return false;
-}
-```
+Selon le `SyncResult` :
 
-`isPlayerCaughtUp` vérifie les deux conditions ci-dessus.
+- `already_caught_up` → on enchaîne sur le handler, rien à dire.
+- `caught_up` avec `generatedPassiveCount > 0` → on envoie un message séparé `📜 Ton équipage a vécu N événement(s). Tape !recap pour les revivre.` **avant** d'enchaîner sur le handler. Les passives ont déjà été appliqués pendant la sync — pas besoin de bloquer.
+- `blocked_on_interactive` → on `throw new OutOfSyncError(message.author.id)`. Le `catch` du routeur rend l'`userView` portée par l'erreur (cf #188) : un embed warn + un bouton "Voir mes events" (`recap-shortcut`) qui ramène vers `!recap`.
+
+> **Pourquoi un message séparé pour le footer plutôt qu'un append à la réponse de la commande** : éviter de coupler chaque handler (pêche, recrutement, etc.) à une logique de footer. UX-wise, deux messages restent fluides, et l'ordre temporel est naturel (footer avant la réponse de l'action).
+
+> **Atomicité** : `synchronizePlayer` tourne dans sa propre transaction. Si le handler échoue après, la sync reste — pas de rollback. Le joueur retape la commande, `already_caught_up` court-circuite et on passe direct à l'action.
 
 ### UX au retour d'AFK
 


### PR DESCRIPTION
## Résumé
-  ajout de`synchronizePlayer` rejoue les buckets en attente du joueur, applique les events passives au fur et à mesure, s'arrête au premier interactif tiré, le tout en une transaction
-  branchée sur le router : toute commande déclenche la synchro avant son handler si elle "requireSynchronization"
- Création de `OutOfSyncError` (qui renvoie une View (embed + bouton) "Voir mes events") , où le bouton redirige vers `!recap` quand un interactif est en attente
- Rename de "AdminOnly" en "RequiresAdmin" pour que ça match mieux avec "RequiresSynchronization"