### PR TITLE
Ameliore commande resolve target

### DIFF
--- a/apps/bot/src/domains/_dev/commands/debug/player.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/player.ts
@@ -4,7 +4,7 @@ import { resolveTargetPlayer } from '../../../player/index.js';
 import { replyDebugData } from './utils.js';
 
 export const handlePlayer: Command['handler'] = async (ctx) => {
-  const targetPlayer = await resolveTargetPlayer(ctx);
+  const { targetPlayer } = await resolveTargetPlayer(ctx);
 
   await replyDebugData(ctx.message, targetPlayer);
 };

--- a/apps/bot/src/domains/_dev/commands/debug/ship.ts
+++ b/apps/bot/src/domains/_dev/commands/debug/ship.ts
@@ -6,7 +6,7 @@ import * as shipRepository from '../../../ship/repository.js';
 import { replyDebugData } from './utils.js';
 
 export const handleShip: Command['handler'] = async (ctx) => {
-  const targetPlayer = await resolveTargetPlayer(ctx);
+  const { targetPlayer } = await resolveTargetPlayer(ctx);
   const ship = await shipRepository.findByPlayerId(targetPlayer.id);
 
   if (!ship) {

--- a/apps/bot/src/domains/crew/commands/crew.ts
+++ b/apps/bot/src/domains/crew/commands/crew.ts
@@ -7,7 +7,7 @@ import { buildCrewView } from '../utils/build-crew-view.js';
 export const crewCommand: Command = {
   name: ['crew', 'equipage', 'team', 'equipe', 'reserve', 'reserv'],
   async handler(ctx) {
-    const targetPlayer = await resolveTargetPlayer(ctx);
+    const { targetPlayer } = await resolveTargetPlayer(ctx);
     const ship = await shipRepository.findByPlayerIdOrThrow(targetPlayer.id);
     const characters = await getCharactersByPlayerId(targetPlayer.id);
     await ctx.message.reply(buildCrewView(targetPlayer, ship, characters, 0, ctx.message.author.id));

--- a/apps/bot/src/domains/fishing/commands/fishing.ts
+++ b/apps/bot/src/domains/fishing/commands/fishing.ts
@@ -6,7 +6,7 @@ import { runFishingAttempt } from '../service.js';
 export const fishingCommand: Command = {
   name: ['fishing', 'fish'],
   async handler(ctx) {
-    const targetPlayer = await resolveTargetPlayer(ctx);
+    const { targetPlayer } = await resolveTargetPlayer(ctx);
     const result = await runFishingAttempt(targetPlayer.id);
 
     const embed = buildOpEmbed()

--- a/apps/bot/src/domains/player/commands/profil.ts
+++ b/apps/bot/src/domains/player/commands/profil.ts
@@ -5,7 +5,7 @@ import { resolveTargetPlayer } from '../utils/index.js';
 export const profilCommand: Command = {
   name: 'profil',
   async handler(ctx) {
-    const targetPlayer = await resolveTargetPlayer(ctx);
+    const { targetPlayer } = await resolveTargetPlayer(ctx);
     await ctx.message.reply(await buildProfilView(targetPlayer.id, ctx.message.author.id));
   },
 };

--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -2,7 +2,7 @@ import { db, player, type DbOrTransaction, type Player, type Zone } from '@one-p
 import { eq } from 'drizzle-orm';
 
 import { NotFoundError } from '../../discord/errors.js';
-import { bucketIdFromTimestamp } from '../event/engine/bucket.js';
+import { getBucketIdFromDate } from '../event/engine/bucket.js';
 
 type FindByIdOptions = {
   forUpdate?: boolean;
@@ -30,7 +30,7 @@ export async function findByDiscordId(discordId: string): Promise<Player | undef
 }
 
 export async function create(discordId: string, name: string, originGuildId: string, transaction: DbOrTransaction = db): Promise<Player> {
-  const lastProcessedBucketId = bucketIdFromTimestamp(new Date());
+  const lastProcessedBucketId = getBucketIdFromDate(new Date());
   const [row] = await transaction.insert(player).values({ discordId, name, originGuildId, lastProcessedBucketId }).returning();
   return row!;
 }

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -3,7 +3,7 @@ import { db, type DbOrTransaction, type Player, type Zone } from '@one-piece/db'
 import { ValidationError } from '../../discord/errors.js';
 import { sanitizeName } from '../../shared/sanitize-name.js';
 import * as characterRepository from '../character/repository.js';
-import { bucketIdFromTimestamp } from '../event/engine/bucket.js';
+import { getLatestProcessableBucket } from '../event/engine/bucket.js';
 import * as eventRepository from '../event/repository.js';
 import * as historyRepository from '../history/index.js';
 import { findOrCreateShip } from '../ship/service.js';
@@ -46,9 +46,9 @@ export async function renamePlayer(playerId: number, rawName: string): Promise<P
 
 export async function isPlayerUpToDate(playerId: number): Promise<boolean> {
   const player = await playerRepository.findByIdOrThrow(playerId);
-  const lastCompleteBucketId = bucketIdFromTimestamp(new Date()) - 1;
+  const latestProcessableBucketId = getLatestProcessableBucket();
 
-  if (player.lastProcessedBucketId < lastCompleteBucketId) {
+  if (player.lastProcessedBucketId < latestProcessableBucketId) {
     return false;
   }
 

--- a/apps/bot/src/domains/player/utils/resolve-target-player.ts
+++ b/apps/bot/src/domains/player/utils/resolve-target-player.ts
@@ -3,10 +3,10 @@ import type { Player } from '@one-piece/db';
 import type { CommandContext } from '../../../discord/types.js';
 import { findOrCreatePlayer } from '../service.js';
 
-export async function resolveTargetPlayer(ctx: CommandContext): Promise<Player> {
+export async function resolveTargetPlayer(ctx: CommandContext): Promise<{ targetPlayer: Player; rest: Array<string> }> {
   const mentioned = ctx.message.mentions.users.first();
-  if (!mentioned) return ctx.player;
+  if (!mentioned) return { targetPlayer: ctx.player, rest: ctx.args };
 
   const { player } = await findOrCreatePlayer(mentioned.id, mentioned.username, ctx.guild.id);
-  return player;
+  return { targetPlayer: player, rest: ctx.args.slice(1) };
 }

--- a/apps/bot/src/domains/resource/commands/inventaire.ts
+++ b/apps/bot/src/domains/resource/commands/inventaire.ts
@@ -6,7 +6,7 @@ import { getInventory } from '../repository.js';
 export const inventaireCommand: Command = {
   name: 'inventaire',
   async handler(ctx) {
-    const targetPlayer = await resolveTargetPlayer(ctx);
+    const { targetPlayer } = await resolveTargetPlayer(ctx);
     const inventory = await getInventory(targetPlayer.id);
 
     await ctx.message.reply(buildInventoryView(targetPlayer, inventory, 0, ctx.message.author.id));

--- a/apps/bot/src/domains/ship/commands/ship.ts
+++ b/apps/bot/src/domains/ship/commands/ship.ts
@@ -5,7 +5,7 @@ import { buildShipView } from '../views/index.js';
 export const shipCommand: Command = {
   name: 'ship',
   async handler(ctx) {
-    const targetPlayer = await resolveTargetPlayer(ctx);
+    const { targetPlayer } = await resolveTargetPlayer(ctx);
     await ctx.message.reply(await buildShipView(targetPlayer, ctx.message.author.id));
   },
 };


### PR DESCRIPTION
# `resolveTargetPlayer`  qu'est-ce qui a changé ?

## Avant
```ts
const targetPlayer = await resolveTargetPlayer(ctx);
```
La fonction renvoyait juste un `Player`

## Après
```ts
const { targetPlayer, restArgs } = await resolveTargetPlayer(ctx);
```
Maintenant elle renvoie un **objet** avec deux choses : le Player cible (targetPlayer), et les args restants (voir après pk)

## Pourquoi un objet ?

Quand une fonction veut renvoyer plusieurs valeurs liées, on les met dans un objet. Le destructuring (`const { targetPlayer, restArgs } = ...`) permet d'extraire chaque champ par son nom en une ligne.

Différence avec l'ancienne syntaxe :
- `const targetPlayer = ...` → on récupère **toute** la valeur de retour dans une variable.
- `const { targetPlayer } = ...` → la valeur de retour est un objet, et on en extrait juste le champ `targetPlayer`.

Avantage : si demain la fonction renvoie un troisième champ, les anciens endroits où on l'appelle continuent de marcher sans rien changer (ils ignorent juste le nouveau vu qu'ils le déstructurent pas)

## Pourquoi ça s'appelle "resolve" ?

"Resolve" = "déterminer/trouver/résoudre". Ici la fonction prend le contexte de la commande et **détermine** quel joueur est la cible

Cas d'usage :
- `!profil` (sans mention) → cible = toi-même.
- `!profil @hakim` → cible = Hakim.
- `!giveressource @ilyess pomme` → cible = Ilyess, et `pomme` reste un argument à traiter.

C'est elle qui va chercher s'il y a un `@quelqu'un` dans le message, et retourne soit lui, soit toi par défaut. D'où "resolve" : elle résout l'ambiguïté "qui est le joueur visé ?".

## Pourquoi `slice(1)` ?

`ctx.args` c'est le tableau des mots tapés après le nom de la commande.

Pour `!giveresource @hakim pomme banane` :
```
ctx.args = ['<@123456>', 'pomme', 'banane'] // @123456 c'est genre son ID discord
```

Le premier élément (`<@123456>`) c'est la mention Discord (Discord encode les @ comme ça en interne). Si on a détecté qu'il y a une mention, on veut que les **vrais** arguments métier soient `['pomme', 'banane']`, sans la mention

`array.slice(1)` retourne une **copie** du tableau à partir de l'index 1 (donc en zappant l'élément 0) :

```ts
['<@123456>', 'pomme', 'banane'].slice(1)
// → ['pomme', 'banane']
```

S'il n'y a pas de mention, on retourne `ctx.args` tel quel, pas besoin de faire de modif dessus

## Exemple complet

```ts
async handler(ctx) {
  const { targetPlayer, restArgs } = await resolveTargetPlayer(ctx);
  const [resourceName, quantity] = restArgs;
  // ...
}
```

Pour `!give @hakim pomme 3` :
- `targetPlayer` = Hakim
- `restArgs` = `['pomme', '3']`

Pour `!give pomme 3` (sans mention) :
- `targetPlayer` = toi
- `restArgs` = `['pomme', '3']`

Le code du handler est identique dans les deux cas, c'est ça qui rend le pattern propre : la commande ne fait pas de cas particulier selon qu'il y ait une mention ou non
