### PR TITLE
add World map

### DIFF
--- a/apps/bot/src/domains/navigation/world.ts
+++ b/apps/bot/src/domains/navigation/world.ts
@@ -1,7 +1,6 @@
-import type { ResourceName } from '@one-piece/db';
-import { type Island, type Sea } from '@one-piece/db';
+import type { ResourceName, Island, Sea } from '@one-piece/db';
 
-type TravailRequirement = { kind: 'item'; name: ResourceName };
+type TravelRequirement = { kind: 'item'; name: ResourceName };
 
 type TravelModifier = { kind: 'no_navigator'; multiplier: number };
 
@@ -10,8 +9,8 @@ type Edge = {
   to: Island;
   via: Sea;
   baseDurationBuckets: number;
-  requires?: Array<TravailRequirement>;
-  Modifiers?: Array<TravelModifier>;
+  requirements?: Array<TravelRequirement>;
+  modifiers?: Array<TravelModifier>;
 };
 
 export const ZONE_GRAPH = [
@@ -22,27 +21,27 @@ export const ZONE_GRAPH = [
     to: 'whisky_peak',
     via: 'sea_paradise',
     baseDurationBuckets: 12,
-    requires: [{ kind: 'item', name: 'Log Pose' }],
+    requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
   {
     from: 'whisky_peak',
     to: 'little_garden',
     via: 'sea_paradise',
     baseDurationBuckets: 18,
-    requires: [{ kind: 'item', name: 'Log Pose' }],
+    requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
   {
     from: 'little_garden',
     to: 'drum',
     via: 'sea_paradise',
     baseDurationBuckets: 25,
-    requires: [{ kind: 'item', name: 'Log Pose' }],
+    requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
   {
     from: 'drum',
     to: 'alabasta',
     via: 'sea_paradise',
     baseDurationBuckets: 30,
-    requires: [{ kind: 'item', name: 'Log Pose' }],
+    requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
 ] satisfies Array<Edge>;

--- a/apps/bot/src/domains/navigation/world.ts
+++ b/apps/bot/src/domains/navigation/world.ts
@@ -1,0 +1,49 @@
+import { ISLANDS, SEAS, ZONES, type Island, type Sea, type Zone } from '@one-piece/db';
+
+export { ISLANDS, SEAS, ZONES, type Island, type Sea, type Zone };
+
+type TravelCondition = { kind: 'item'; name: string };
+
+type TravelModifier = { kind: 'no_navigator'; multiplier: number };
+
+type Edge = {
+  from: Island;
+  to: Island;
+  via: Sea;
+  baseDurationBuckets: number;
+  requires?: Array<TravelCondition>;
+  softModifiers?: Array<TravelModifier>;
+};
+
+export const ZONE_GRAPH = [
+  { from: 'foosha', to: 'loguetown', via: 'sea_east_blue', baseDurationBuckets: 6 },
+  { from: 'loguetown', to: 'reverse_mountain', via: 'sea_east_blue', baseDurationBuckets: 8 },
+  {
+    from: 'reverse_mountain',
+    to: 'whisky_peak',
+    via: 'sea_paradise',
+    baseDurationBuckets: 12,
+    requires: [{ kind: 'item', name: 'Log Pose' }],
+  },
+  {
+    from: 'whisky_peak',
+    to: 'little_garden',
+    via: 'sea_paradise',
+    baseDurationBuckets: 18,
+    requires: [{ kind: 'item', name: 'Log Pose' }],
+  },
+  {
+    from: 'little_garden',
+    to: 'drum',
+    via: 'sea_paradise',
+    baseDurationBuckets: 25,
+    requires: [{ kind: 'item', name: 'Log Pose' }],
+  },
+  {
+    from: 'drum',
+    to: 'alabasta',
+    via: 'sea_paradise',
+    baseDurationBuckets: 30,
+    requires: [{ kind: 'item', name: 'Log Pose' }],
+  },
+] satisfies Array<Edge>;

--- a/apps/bot/src/domains/navigation/world.ts
+++ b/apps/bot/src/domains/navigation/world.ts
@@ -1,8 +1,7 @@
-import { ISLANDS, SEAS, ZONES, type Island, type Sea, type Zone } from '@one-piece/db';
+import type { ResourceName } from '@one-piece/db';
+import { type Island, type Sea } from '@one-piece/db';
 
-export { ISLANDS, SEAS, ZONES, type Island, type Sea, type Zone };
-
-type TravelCondition = { kind: 'item'; name: string };
+type TravailRequirement = { kind: 'item'; name: ResourceName };
 
 type TravelModifier = { kind: 'no_navigator'; multiplier: number };
 
@@ -11,8 +10,8 @@ type Edge = {
   to: Island;
   via: Sea;
   baseDurationBuckets: number;
-  requires?: Array<TravelCondition>;
-  softModifiers?: Array<TravelModifier>;
+  requires?: Array<TravailRequirement>;
+  Modifiers?: Array<TravelModifier>;
 };
 
 export const ZONE_GRAPH = [


### PR DESCRIPTION
## Résumé

Ajout du graphe initial de navigation dans `apps/bot/src/domains/navigation/world.ts`.

## Changements


- Ajoute les types `TravelCondition`, `TravelModifier` et `Edge`.
- Déclare `ZONE_GRAPH` avec les arêtes V1 linéaires :
  `foosha -> loguetown -> reverse_mountain -> whisky_peak -> little_garden -> drum -> alabasta`.
- Ajoute la condition `Log Pose` sur les routes de Paradise.
- Utilise `satisfies Array<Edge>` pour valider le graphe sans perdre les types littéraux.
