### PR TITLE
implementation de barrel found

### DIFF
--- a/apps/bot/src/domains/event/engine/synchronize-player.ts
+++ b/apps/bot/src/domains/event/engine/synchronize-player.ts
@@ -96,7 +96,7 @@ export async function synchronizePlayer(playerId: number): Promise<SyncResult> {
         const picked = pickRandomWithSeed(seedFromBucketAndPlayer(bucketId, playerId), candidates);
 
         await eventRepository.insertWithIdempotence(
-          { playerId, eventKey: picked.key, isInteractive: true, bucketId, state: { step: picked.initial } },
+          { playerId, eventKey: picked.key, isInteractive: true, bucketId, state: { step: picked.initialStep } },
           tx,
         );
         await playerRepository.setLastProcessedBucketId(playerId, bucketId, tx);

--- a/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
+++ b/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
@@ -1,0 +1,39 @@
+import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
+import type { GeneratorContext, InteractiveGenerator, Resolution, Rng } from '../../types.js';
+import { getRandomIntBetween } from '../utils.js';
+
+export const barrelFound: InteractiveGenerator = {
+  key: 'fishing.barrel_found',
+  isInteractive: true,
+  seedScope: 'player',
+  cooldownBuckets: 2,
+  probability: () => 0.1,
+
+  initialStep: 'openOrLeave',
+  steps: {
+    openOrLeave: {
+      embed: () => buildOpEmbed('info').setTitle('Un baril flotte près du navire.'),
+      choices: () => [
+        { id: 'open', label: 'Ouvrir', resolve: openBarrel },
+        { id: 'leave', label: 'Laisser', resolve: leaveBarrel },
+      ],
+    },
+  },
+};
+
+function openBarrel(_ctx: GeneratorContext, rng: Rng): Resolution {
+  const berries = getRandomIntBetween(rng, 100, 1000);
+  return {
+    embed: buildOpEmbed('success').setTitle(`Tu trouves ${berries} berries dans le baril.`),
+    effects: [{ type: 'addBerries', amount: BigInt(berries) }],
+    resolutionType: 'fishing.barrel_found.opened',
+  };
+}
+
+function leaveBarrel(): Resolution {
+  return {
+    embed: buildOpEmbed('info').setTitle('Tu passes ton chemin.'),
+    effects: [],
+    resolutionType: 'fishing.barrel_found.left',
+  };
+}

--- a/apps/bot/src/domains/event/generators/interactive/registry.ts
+++ b/apps/bot/src/domains/event/generators/interactive/registry.ts
@@ -1,3 +1,5 @@
 import type { InteractiveGenerator } from '../../types.js';
 
-export const interactiveGenerators: Array<InteractiveGenerator> = [];
+import { barrelFound } from './barrel-found.js';
+
+export const interactiveGenerators: Array<InteractiveGenerator> = [barrelFound];

--- a/apps/bot/src/domains/event/generators/utils.ts
+++ b/apps/bot/src/domains/event/generators/utils.ts
@@ -1,3 +1,10 @@
+import type { Rng } from '../types.js';
+
 export function computeNothing() {
   return { effects: [], state: {} };
+}
+
+/** Entier dans [min, max] (bornes incluses) tiré depuis le rng fourni. */
+export function getRandomIntBetween(rng: Rng, min: number, max: number): number {
+  return Math.floor(rng.next() * (max - min + 1)) + min;
 }

--- a/apps/bot/src/domains/event/types.ts
+++ b/apps/bot/src/domains/event/types.ts
@@ -62,7 +62,7 @@ type InteractiveStep = {
 
 export type InteractiveGenerator = GeneratorBase & {
   isInteractive: true;
-  initial: string;
+  initialStep: string;
   steps: Record<string, InteractiveStep>;
 };
 

--- a/docs/domains/event/generators.md
+++ b/docs/domains/event/generators.md
@@ -84,12 +84,12 @@ const fishingHaul: PassiveGenerator = {
 ## Forme interactive 1 étape
 
 ```ts
-const barrelFound: EventGenerator = {
+const barrelFound: InteractiveGenerator = {
   key: 'fishing.barrel_found',
   isInteractive: true,
   seedScope: 'player',
   probability: () => 0.1,
-  initial: 'choice',
+  initialStep: 'choice',
   steps: {
     choice: {
       embed: () => buildOpEmbed('info').setTitle('Un baril flotte près du navire.'),
@@ -120,13 +120,13 @@ function openBarrel(ctx, rng) {
 ## Forme interactive multi-étapes (graphe)
 
 ```ts
-const defeatCrocodile: EventGenerator = {
+const defeatCrocodile: InteractiveGenerator = {
   key: 'mainstory.alabasta.defeat_crocodile',
   isInteractive: true,
   seedScope: 'player', // mainstory perso
   conditions: (ctx) => ctx.history.has('mainstory.alabasta.save_vivi.resolved') && ctx.player.hasItem('haki_basic'),
   probability: () => 1.0,
-  initial: 'opener',
+  initialStep: 'opener',
   steps: {
     opener: {
       embed: () => buildOpEmbed('info').setTitle('Crocodile se dresse devant toi.'),
@@ -260,7 +260,7 @@ C'est cette table qui rend possibles `conditions`, `cooldownBuckets`, `oneTime`,
 ## Ajouter un nouvel event
 
 1. Créer `generators/<famille>/<nom>.ts`.
-2. Exporter un `EventGenerator` qui respecte le contrat (`types.ts`).
+2. Exporter un `Genrator` qui respecte le contrat (`types.ts`).
 3. L'ajouter dans `registry.ts`.
 4. Si nouveau type d'effet : étendre l'union `EventEffect` + ajouter le handler dans `apply-effects.ts`.
 5. Si nouveau `resolutionType` : déclarer le payload dans `apps/bot/src/domains/history/types/event.ts` (cf `history.md`).


### PR DESCRIPTION
## Résumé
- Création du tout premier event interactif barrel found
- création de l'util getRandomIntegerBetween .. qui retourne un random int entre deux nombres, et basé sur une seed (qui permet se retirer le meme nombre avec la meme seed
- Modification de la clé initial en initialStep car c'est plus lisible pour les générateurs
- Update de la doc avec les nouveaux termes

## Exemples
- Exemple de !crew bloqué car j'ai un pendingInteractive
<img width="436" height="184" alt="image" src="https://github.com/user-attachments/assets/5310a273-4590-425f-b07e-d35b9d84be11" />

- Table event instance : (avec step à choice, car c'est le initialStep)
<img width="1260" height="103" alt="image" src="https://github.com/user-attachments/assets/ac3294d7-1a45-49b1-a5bc-f5d0e5883f14" />
