### PR TITLE
237 feature logger chaque fishing dans history test

### DIFF
--- a/apps/bot/src/domains/fishing/service.ts
+++ b/apps/bot/src/domains/fishing/service.ts
@@ -1,5 +1,6 @@
 import sample from 'lodash/sample.js';
 
+import * as historyRepository from '../history/index.js';
 import * as resourceRepository from '../resource/repository.js';
 
 export type FishingResult = { quantity: number; resourceName: string };
@@ -12,5 +13,14 @@ export async function runFishingAttempt(playerId: number): Promise<FishingResult
   if (!picked) throw new Error('Aucun resource_template en base — exécute le seed avant de pêcher.');
 
   await resourceRepository.addResourceToPlayer(playerId, picked.id, 1);
+  // TODO: SUPPRIMER EN PROD — log de test pour valider history
+  await historyRepository.appendHistory({
+    type: 'fishing.attempt',
+    payload: {
+      quantity: 1,
+      resourceName: picked.name,
+    },
+    actorPlayerId: playerId,
+  });
   return { quantity: 1, resourceName: picked.name };
 }

--- a/apps/bot/src/domains/history/types/fishing.ts
+++ b/apps/bot/src/domains/history/types/fishing.ts
@@ -1,0 +1,9 @@
+export type FishingAttemptLog = {
+  type: 'fishing.attempt';
+  payload: {
+    quantity: number;
+    resourceName: string;
+  };
+};
+
+export type FishingLog = FishingAttemptLog;

--- a/apps/bot/src/domains/history/types/index.ts
+++ b/apps/bot/src/domains/history/types/index.ts
@@ -1,4 +1,5 @@
 import type { CrewLog } from './crew.js';
+import type { FishingLog } from './fishing.js';
 import type { PlayerLog } from './player.js';
 
-export type Log = CrewLog | PlayerLog;
+export type Log = CrewLog | PlayerLog | FishingLog;


### PR DESCRIPTION
## Contexte

  Pour préparer de futures stats de pêche, on a besoin d'un log append-only à chaque tentative. Ce ticket pose les bases
   en branchant le domaine history sur la commande pêche.

  ## Ce qui a été fait

  - Ajout d'un type FishingLog (fishing.attempt) avec sa payload { quantity, resourceName } dans
  history/types/fishing.ts
  - Intégration de FishingLog dans l'union Log de history/types/index.ts
  - Appel de appendHistory dans fishing/service.ts après chaque pêche réussie, marqué TODO: SUPPRIMER EN PROD — code
  temporaire de test

 ## Hors scope

  Pas de lecture, pas de stats, pas de modif de schéma. Uniquement l'écriture en base.

  ## Test

  Validé manuellement via Drizzle Studio — une ligne insérée dans history à chaque $fishing avec le bon event_type et la
   payload attendue.


<img width="510" height="239" alt="image" src="https://github.com/user-attachments/assets/8e16d739-c38c-40e5-aef9-82078bcaf176" />

<img width="836" height="135" alt="image" src="https://github.com/user-attachments/assets/46965f8d-e54f-4a67-8a41-7905d79cf501" />
