### PR TITLE
added helper

### DIFF
--- a/apps/bot/src/domains/event/engine/bucket.ts
+++ b/apps/bot/src/domains/event/engine/bucket.ts
@@ -1,3 +1,5 @@
+import type { GeneratorContext } from '../types.js';
+
 export const BUCKET_DURATION_SEC = 15 * 60;
 
 export function getBucketIdFromDate(date: Date): number {
@@ -15,4 +17,9 @@ export function getEndDateOfBucket(bucketId: number): Date {
 /** Dernier bucket complet (= courant - 1). Le bucket en cours n'est pas traité tant qu'il n'est pas terminé. */
 export function getLatestProcessableBucket(): number {
   return getBucketIdFromDate(new Date()) - 1;
+}
+
+export function bucketsUntilEta(ctx: GeneratorContext): number {
+  if (ctx.player.travelEtaBucket === null) return Number.POSITIVE_INFINITY;
+  return ctx.player.travelEtaBucket - ctx.bucketId;
 }

--- a/apps/bot/src/domains/navigation/world-helpers.ts
+++ b/apps/bot/src/domains/navigation/world-helpers.ts
@@ -1,6 +1,0 @@
-import type { GeneratorContext } from '../event/types.js';
-
-export function bucketsUntilEta(ctx: GeneratorContext): number {
-  if (ctx.player.travelEtaBucket === null) return Number.POSITIVE_INFINITY;
-  return ctx.player.travelEtaBucket - ctx.bucketId;
-}

--- a/apps/bot/src/domains/navigation/world-helpers.ts
+++ b/apps/bot/src/domains/navigation/world-helpers.ts
@@ -1,0 +1,6 @@
+import type { GeneratorContext } from '../event/types.js';
+
+export function bucketsUntilEta(ctx: GeneratorContext): number {
+  if (ctx.player.travelEtaBucket === null) return Number.POSITIVE_INFINITY;
+  return ctx.player.travelEtaBucket - ctx.bucketId;
+}


### PR DESCRIPTION
## Contexte

  Pour permettre les approach events (ex: "tu aperçois Drum à l'horizon"), on a besoin d'un helper qui indique combien
  de buckets il reste avant l'arrivée du joueur.

  ## Ce qui a été fait

  - Création du dossier navigation/ et du fichier world-helpers.ts
  - Ajout de bucketsUntilEta(ctx) : retourne Number.POSITIVE_INFINITY si le joueur n'est pas en transit, sinon
  travelEtaBucket - bucketId

  ## Usage cible

  ctx.zone === 'sea_paradise' && bucketsUntilEta(ctx) <= 4

  ## Hors scope

  Les approach events eux-mêmes — ce ticket ajoute uniquement le helper.