### PR TITLE
add recordZoneChange

### DIFF
--- a/apps/bot/src/domains/history/repository.ts
+++ b/apps/bot/src/domains/history/repository.ts
@@ -57,12 +57,18 @@ type WriteEventResolutionArgs = {
   // TODO: renommer en `kind` quand history.event_type sera renommé (cf packages/db/src/domains/history/schema.ts)
   eventType: string;
   bucketId: number;
+  payload?: JSONFromSQL;
 };
 
 export async function writeEventResolution(args: WriteEventResolutionArgs, client: DbOrTransaction = db): Promise<void> {
   await client
     .insert(history)
-    .values(args)
+    .values({
+      actorPlayerId: args.actorPlayerId,
+      eventType: args.eventType,
+      bucketId: args.bucketId,
+      ...(args.payload === undefined ? {} : { payload: args.payload }),
+    })
     .onConflictDoNothing({
       target: [history.actorPlayerId, history.eventType, history.bucketId],
       where: sql`${history.actorPlayerId} IS NOT NULL AND ${history.bucketId} IS NOT NULL`,

--- a/apps/bot/src/domains/navigation/world.ts
+++ b/apps/bot/src/domains/navigation/world.ts
@@ -1,10 +1,10 @@
 import type { ResourceName, Island, Sea } from '@one-piece/db';
 
-type TravelRequirement = { kind: 'item'; name: ResourceName };
+export type TravelRequirement = { kind: 'item'; name: ResourceName };
 
-type TravelModifier = { kind: 'no_navigator'; multiplier: number };
+export type TravelModifier = { kind: 'no_navigator'; multiplier: number };
 
-type Edge = {
+export type Edge = {
   from: Island;
   to: Island;
   via: Sea;

--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -3,9 +3,26 @@ import { eq } from 'drizzle-orm';
 
 import { NotFoundError } from '../../discord/errors.js';
 import { getNowBucketId } from '../event/engine/bucket.js';
+import * as historyRepository from '../history/index.js';
+import type { Edge } from '../navigation/world.js';
 
 type FindByIdOptions = {
   forUpdate?: boolean;
+};
+
+type RecordZoneChangeInput = {
+  playerId: number;
+  newZone: Zone;
+  bucketId?: number;
+  at?: Date;
+  client?: DbOrTransaction;
+};
+
+type StartTravelInput = {
+  playerId: number;
+  edge: Edge;
+  etaBucket: number;
+  client?: DbOrTransaction;
 };
 
 export async function findById(id: number, client: DbOrTransaction = db, options: FindByIdOptions = {}): Promise<Player | undefined> {
@@ -43,6 +60,71 @@ export async function updateName(playerId: number, name: string, client: DbOrTra
 export async function updateZone(playerId: number, zone: Zone, client: DbOrTransaction = db): Promise<void> {
   await client.update(player).set({ currentZone: zone }).where(eq(player.id, playerId));
 }
+
+export async function recordZoneChange({
+  playerId,
+  newZone,
+  bucketId = getNowBucketId(),
+  at,
+  client = db,
+}: RecordZoneChangeInput): Promise<void> {
+  const currentPlayer = await findByIdOrThrow(playerId, client);
+  const from = currentPlayer.currentZone;
+
+  await updateZone(playerId, newZone, client);
+  await historyRepository.appendHistory({
+    type: 'player.zone_changed',
+    actorPlayerId: playerId,
+    bucketId,
+    payload: { from, to: newZone },
+    client,
+    occurredAt: at,
+  });
+}
+
+async function persistTravel({ playerId, edge, etaBucket }: StartTravelInput, transaction: DbOrTransaction): Promise<void> {
+  const travelStartedBucket = getNowBucketId();
+  const occurredAt = new Date();
+
+  await transaction
+    .update(player)
+    .set({
+      travelTargetZone: edge.to,
+      travelStartedBucket,
+      travelEtaBucket: etaBucket,
+    })
+    .where(eq(player.id, playerId));
+
+  await recordZoneChange({
+    playerId,
+    newZone: edge.via,
+    bucketId: travelStartedBucket,
+    at: occurredAt,
+    client: transaction,
+  });
+
+  await historyRepository.writeEventResolution(
+    {
+      actorPlayerId: playerId,
+      eventType: 'travel.departed',
+      bucketId: travelStartedBucket,
+      payload: { from: edge.from, to: edge.to, viaSea: edge.via, etaBucket },
+    },
+    transaction,
+  );
+}
+
+export async function startTravel(input: StartTravelInput): Promise<void> {
+  const client = input.client ?? db;
+
+  if (client === db) {
+    await db.transaction(async (transaction) => persistTravel(input, transaction));
+    return;
+  }
+
+  await persistTravel(input, client);
+}
+
 export async function updateCrewName(playerId: number, crewName: string, client: DbOrTransaction = db): Promise<Player> {
   const [row] = await client.update(player).set({ crewName }).where(eq(player.id, playerId)).returning();
   return row!;

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -5,7 +5,6 @@ import { sanitizeName } from '../../shared/sanitize-name.js';
 import * as characterRepository from '../character/repository.js';
 import { getLatestProcessableBucket } from '../event/engine/bucket.js';
 import * as eventRepository from '../event/repository.js';
-import * as historyRepository from '../history/index.js';
 import { findOrCreateShip } from '../ship/service.js';
 
 import { assertNameNotEmpty, assertNameWithinMaxLength } from './guards/index.js';
@@ -58,17 +57,8 @@ export async function isPlayerUpToDate(playerId: number): Promise<boolean> {
 }
 
 export async function recordZoneChange(playerId: number, newZone: Zone, bucketId: number, client: DbOrTransaction = db): Promise<void> {
-  const currentPlayer = await playerRepository.findByIdOrThrow(playerId, client);
-  const from = currentPlayer.currentZone;
+  const player = await playerRepository.findByIdOrThrow(playerId, client);
+  if (player.currentZone === newZone) throw new ValidationError('Vous êtes déjà à cet endroit');
 
-  if (from === newZone) throw new ValidationError('Vous êtes déjà à cet endroit');
-
-  await playerRepository.updateZone(playerId, newZone, client);
-  await historyRepository.appendHistory({
-    type: 'player.zone_changed',
-    actorPlayerId: playerId,
-    bucketId,
-    payload: { from, to: newZone },
-    client,
-  });
+  await playerRepository.recordZoneChange({ playerId, newZone, bucketId, client });
 }


### PR DESCRIPTION
## Résumé

- Ajout de `startTravel` dans le repository player pour persister un départ en voyage de façon atomique.
- Mise à jour des colonnes `travel_*`, bascule du joueur vers la zone de mer, et ajout de l’entrée history `travel.departed`.
- Export du type `Edge` depuis le module navigation.
- Ajout d’un `payload` optionnel à `writeEventResolution`.