### PR TITLE
time old event

### DIFF
--- a/apps/bot/src/discord/router.ts
+++ b/apps/bot/src/discord/router.ts
@@ -48,7 +48,7 @@ export async function routeMessage(message: Message, prefix: string): Promise<vo
     const { player } = await findOrCreatePlayer(message.author.id, message.author.username, guild.id);
 
     if (command.requiresSynchronization !== false) {
-      await autoSyncBeforeAction(message, player.id);
+      await autoSyncBeforeAction(message, player);
     }
 
     await command.handler({ message, args, player, guild });

--- a/apps/bot/src/domains/event/auto-sync-before-action.ts
+++ b/apps/bot/src/domains/event/auto-sync-before-action.ts
@@ -8,6 +8,17 @@ import { getEndDateOfBucket } from './engine/bucket.js';
 import { synchronizePlayer } from './engine/synchronize-player.js';
 import { OutOfSyncError } from './errors.js';
 
+const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
+
+const LONG_AWAY_PHRASES = [
+  'depuis une longue traversée loin des regards',
+  "depuis le retour d'une longue absence en mer",
+  "depuis un vieux récit rapporté par l'équipage",
+];
+
 export async function autoSyncBeforeAction(message: Message, player: Player): Promise<void> {
   const result = await synchronizePlayer(player.id);
 
@@ -30,17 +41,6 @@ export async function autoSyncBeforeAction(message: Message, player: Player): Pr
     });
   }
 }
-
-const HOUR_MS = 60 * 60 * 1000;
-const MINUTE_MS = 60 * 1000;
-const DAY_MS = 24 * HOUR_MS;
-const WEEK_MS = 7 * DAY_MS;
-
-const LONG_AWAY_PHRASES = [
-  'depuis une longue traversée loin des regards',
-  "depuis le retour d'une longue absence en mer",
-  "depuis un vieux récit rapporté par l'équipage",
-];
 
 function pluralize(value: number, singular: string, plural: string): string {
   return `${value} ${value === 1 ? singular : plural}`;

--- a/apps/bot/src/domains/event/auto-sync-before-action.ts
+++ b/apps/bot/src/domains/event/auto-sync-before-action.ts
@@ -8,10 +8,50 @@ import { synchronizePlayer } from './engine/synchronize-player.js';
 import { OutOfSyncError } from './errors.js';
 
 const HOUR_MS = 60 * 60 * 1000;
+const MINUTE_MS = 60 * 1000;
+const DAY_MS = 24 * HOUR_MS;
+const WEEK_MS = 7 * DAY_MS;
 
-function formatElapsedHours(since: Date): string {
-  const elapsedHours = Math.max(0, Math.floor((Date.now() - since.getTime()) / HOUR_MS));
-  return `${elapsedHours} heure${elapsedHours === 1 ? '' : 's'}`;
+function pluralize(value: number, singular: string, plural: string): string {
+  return `${value} ${value === 1 ? singular : plural}`;
+}
+
+function getDayPeriod(date: Date): string {
+  const hour = date.getHours();
+
+  if (hour >= 5 && hour <= 11) return 'matin';
+  if (hour >= 12 && hour <= 17) return "dans l'après-midi";
+  if (hour >= 18 && hour <= 22) return 'dans la soirée';
+  return 'dans la nuit';
+}
+
+function formatElapsedTime(since: Date): string {
+  const elapsedMs = Math.max(0, Date.now() - since.getTime());
+
+  if (elapsedMs < HOUR_MS) {
+    const elapsedMinutes = Math.max(1, Math.floor(elapsedMs / MINUTE_MS));
+    return `depuis ${pluralize(elapsedMinutes, 'minute', 'minutes')}`;
+  }
+
+  if (elapsedMs < DAY_MS) {
+    const elapsedHours = Math.floor(elapsedMs / HOUR_MS);
+    return `depuis ${pluralize(elapsedHours, 'heure', 'heures')}`;
+  }
+
+  if (elapsedMs < WEEK_MS) {
+    const elapsedDays = Math.floor(elapsedMs / DAY_MS);
+    const period = getDayPeriod(since);
+    return elapsedDays === 1 ? `depuis hier ${period}` : `depuis ${pluralize(elapsedDays, 'jour', 'jours')}, ${period}`;
+  }
+
+  const longAwayPhrases = [
+    'depuis une longue traversée loin des regards',
+    "depuis le retour d'une longue absence en mer",
+    "depuis des jours d'aventure aux confins de Grand Line",
+    "depuis un vieux récit rapporté par l'équipage",
+  ];
+  const phraseIndex = Math.floor(since.getTime() / DAY_MS) % longAwayPhrases.length;
+  return longAwayPhrases[phraseIndex]!;
 }
 
 export async function autoSyncBeforeAction(message: Message, player: Player): Promise<void> {
@@ -23,13 +63,14 @@ export async function autoSyncBeforeAction(message: Message, player: Player): Pr
 
   if (result.status === 'caught_up' && result.generatedPassiveCount > 0) {
     const since = getEndDateOfBucket(player.lastProcessedBucketId);
-    const elapsed = formatElapsedHours(since);
+    const elapsed = formatElapsedTime(since);
+    const eventCount = pluralize(result.generatedPassiveCount, 'événement', 'événements');
 
     await message.reply({
       embeds: [
         buildOpEmbed('info').setDescription(
           // TODO: remplacer par le préfixe de la guild
-          `📜 Ton équipage a vécu ${result.generatedPassiveCount} événement(s) depuis ${elapsed}. Tape \`!recap\` pour les revivre.`,
+          `📜 Ton équipage a vécu ${eventCount} ${elapsed}. Tape \`!recap\` pour les revivre.`,
         ),
       ],
     });

--- a/apps/bot/src/domains/event/auto-sync-before-action.ts
+++ b/apps/bot/src/domains/event/auto-sync-before-action.ts
@@ -1,5 +1,6 @@
 import type { Player } from '@one-piece/db';
 import type { Message } from 'discord.js';
+import sample from 'lodash/sample.js';
 
 import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
 
@@ -7,22 +8,42 @@ import { getEndDateOfBucket } from './engine/bucket.js';
 import { synchronizePlayer } from './engine/synchronize-player.js';
 import { OutOfSyncError } from './errors.js';
 
+export async function autoSyncBeforeAction(message: Message, player: Player): Promise<void> {
+  const result = await synchronizePlayer(player.id);
+
+  if (result.status === 'blocked_on_interactive') {
+    throw new OutOfSyncError(message.author.id);
+  }
+
+  if (result.status === 'caught_up' && result.generatedPassiveCount > 0) {
+    const since = getEndDateOfBucket(player.lastProcessedBucketId);
+    const elapsed = formatElapsedTime(since);
+    const eventCountText = pluralize(result.generatedPassiveCount, 'événement', 'événements');
+
+    await message.reply({
+      embeds: [
+        buildOpEmbed('info').setDescription(
+          // TODO: remplacer par le préfixe de la guild
+          `📜 Ton équipage a vécu ${eventCountText} ${elapsed}. Tape \`!recap\` pour les revivre.`,
+        ),
+      ],
+    });
+  }
+}
+
 const HOUR_MS = 60 * 60 * 1000;
 const MINUTE_MS = 60 * 1000;
 const DAY_MS = 24 * HOUR_MS;
 const WEEK_MS = 7 * DAY_MS;
 
+const LONG_AWAY_PHRASES = [
+  'depuis une longue traversée loin des regards',
+  "depuis le retour d'une longue absence en mer",
+  "depuis un vieux récit rapporté par l'équipage",
+];
+
 function pluralize(value: number, singular: string, plural: string): string {
   return `${value} ${value === 1 ? singular : plural}`;
-}
-
-function getDayPeriod(date: Date): string {
-  const hour = date.getHours();
-
-  if (hour >= 5 && hour <= 11) return 'matin';
-  if (hour >= 12 && hour <= 17) return "dans l'après-midi";
-  if (hour >= 18 && hour <= 22) return 'dans la soirée';
-  return 'dans la nuit';
 }
 
 function formatElapsedTime(since: Date): string {
@@ -44,35 +65,14 @@ function formatElapsedTime(since: Date): string {
     return elapsedDays === 1 ? `depuis hier ${period}` : `depuis ${pluralize(elapsedDays, 'jour', 'jours')}, ${period}`;
   }
 
-  const longAwayPhrases = [
-    'depuis une longue traversée loin des regards',
-    "depuis le retour d'une longue absence en mer",
-    "depuis des jours d'aventure aux confins de Grand Line",
-    "depuis un vieux récit rapporté par l'équipage",
-  ];
-  const phraseIndex = Math.floor(since.getTime() / DAY_MS) % longAwayPhrases.length;
-  return longAwayPhrases[phraseIndex]!;
+  return sample(LONG_AWAY_PHRASES)!;
 }
 
-export async function autoSyncBeforeAction(message: Message, player: Player): Promise<void> {
-  const result = await synchronizePlayer(player.id);
+function getDayPeriod(date: Date): string {
+  const hour = date.getHours();
 
-  if (result.status === 'blocked_on_interactive') {
-    throw new OutOfSyncError(message.author.id);
-  }
-
-  if (result.status === 'caught_up' && result.generatedPassiveCount > 0) {
-    const since = getEndDateOfBucket(player.lastProcessedBucketId);
-    const elapsed = formatElapsedTime(since);
-    const eventCount = pluralize(result.generatedPassiveCount, 'événement', 'événements');
-
-    await message.reply({
-      embeds: [
-        buildOpEmbed('info').setDescription(
-          // TODO: remplacer par le préfixe de la guild
-          `📜 Ton équipage a vécu ${eventCount} ${elapsed}. Tape \`!recap\` pour les revivre.`,
-        ),
-      ],
-    });
-  }
+  if (hour >= 5 && hour <= 11) return 'matin';
+  if (hour >= 12 && hour <= 17) return "dans l'après-midi";
+  if (hour >= 18 && hour <= 22) return 'dans la soirée';
+  return 'dans la nuit';
 }

--- a/apps/bot/src/domains/event/auto-sync-before-action.ts
+++ b/apps/bot/src/domains/event/auto-sync-before-action.ts
@@ -1,23 +1,35 @@
+import type { Player } from '@one-piece/db';
 import type { Message } from 'discord.js';
 
 import { buildOpEmbed } from '../../discord/utils/build-op-embed.js';
 
+import { getEndDateOfBucket } from './engine/bucket.js';
 import { synchronizePlayer } from './engine/synchronize-player.js';
 import { OutOfSyncError } from './errors.js';
 
-export async function autoSyncBeforeAction(message: Message, playerId: number): Promise<void> {
-  const result = await synchronizePlayer(playerId);
+const HOUR_MS = 60 * 60 * 1000;
+
+function formatElapsedHours(since: Date): string {
+  const elapsedHours = Math.max(0, Math.floor((Date.now() - since.getTime()) / HOUR_MS));
+  return `${elapsedHours} heure${elapsedHours === 1 ? '' : 's'}`;
+}
+
+export async function autoSyncBeforeAction(message: Message, player: Player): Promise<void> {
+  const result = await synchronizePlayer(player.id);
 
   if (result.status === 'blocked_on_interactive') {
     throw new OutOfSyncError(message.author.id);
   }
 
   if (result.status === 'caught_up' && result.generatedPassiveCount > 0) {
+    const since = getEndDateOfBucket(player.lastProcessedBucketId);
+    const elapsed = formatElapsedHours(since);
+
     await message.reply({
       embeds: [
         buildOpEmbed('info').setDescription(
           // TODO: remplacer par le préfixe de la guild
-          `📜 Ton équipage a vécu ${result.generatedPassiveCount} événement(s). Tape \`!recap\` pour les revivre.`,
+          `📜 Ton équipage a vécu ${result.generatedPassiveCount} événement(s) depuis ${elapsed}. Tape \`!recap\` pour les revivre.`,
         ),
       ],
     });


### PR DESCRIPTION
## Résumé

- Passe le `player` complet à `autoSyncBeforeAction` depuis le router.
- Utilise `player.lastProcessedBucketId` avant la synchronisation pour calculer depuis quand les événements passifs se sont accumulés.
- Met à jour le message d’auto-sync pour afficher la durée écoulée en heures.
