### PR TITLE
add inBuckets util et changement partout

### DIFF
--- a/apps/bot/src/domains/event/engine/bucket.ts
+++ b/apps/bot/src/domains/event/engine/bucket.ts
@@ -1,6 +1,8 @@
 import type { GeneratorContext } from '../types.js';
 
-export const BUCKET_DURATION_SEC = 15 * 60;
+const BUCKET_DURATION_MIN = 15;
+
+const BUCKET_DURATION_SEC = BUCKET_DURATION_MIN * 60;
 
 export function getBucketIdFromDate(date: Date): number {
   return Math.floor(date.getTime() / 1000 / BUCKET_DURATION_SEC);
@@ -26,4 +28,24 @@ export function getLatestProcessableBucket(): number {
 export function bucketsUntilEta(ctx: GeneratorContext): number {
   if (ctx.player.travelEtaBucket === null) return Number.POSITIVE_INFINITY;
   return ctx.player.travelEtaBucket - ctx.bucketId;
+}
+
+type Unit = 'm' | 'h' | 'd';
+type Duration = `${number}${Unit}`;
+
+const UNIT_TO_MINUTES = { m: 1, h: 60, d: 60 * 24 } as const;
+const DURATION_REGEX = /^(?<value>\d+)(?<unit>[mhd])$/;
+
+/** Convertit une durée ("30m", "5h", "2d") en nombre de buckets. Throw si illisible/ne donne pas un nombre de buckets ENTIERS et > 0 */
+export function inBuckets(duration: Duration): number {
+  const match = DURATION_REGEX.exec(duration);
+
+  if (!match) throw new Error(`Durée invalide: "${duration}"`);
+  const { value, unit } = match.groups as { value: string; unit: Unit };
+  const minutes = Number(value) * UNIT_TO_MINUTES[unit];
+
+  if (minutes === 0 || minutes % BUCKET_DURATION_MIN !== 0) {
+    throw new Error(`"${duration}" ne fait pas un nombre entier de buckets`);
+  }
+  return minutes / BUCKET_DURATION_MIN;
 }

--- a/apps/bot/src/domains/event/engine/clamp-replay-window.ts
+++ b/apps/bot/src/domains/event/engine/clamp-replay-window.ts
@@ -1,10 +1,9 @@
-import { BUCKET_DURATION_SEC } from './bucket.js';
+import { inBuckets } from './bucket.js';
 
-const MAX_HOURS_TO_REPLAY = 48;
-const MAX_BUCKETS_TO_REPLAY = (MAX_HOURS_TO_REPLAY * 60 * 60) / BUCKET_DURATION_SEC;
+const MAX_BUCKETS_TO_REPLAY = inBuckets('48h');
 
 /**
- * Borne le bucket de départ à la fenêtre de replay MAX_HOURS_TO_REPLAY (48h max).
+ * Borne le bucket de départ à la fenêtre de replay (48h max).
  * Si le joueur est AFK depuis plus longtemps, les buckets en dehors de la fenêtre sont silencieusement perdus.
  */
 export function clampToReplayWindow(fromBucket: number, latestProcessableBucket: number): number {

--- a/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
+++ b/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
@@ -1,4 +1,5 @@
 import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
+import { inBuckets } from '../../engine/bucket.js';
 import type { GeneratorContext, InteractiveGenerator, Resolution, Rng } from '../../types.js';
 import { getRandomIntBetween } from '../utils.js';
 
@@ -6,8 +7,8 @@ export const barrelFound: InteractiveGenerator = {
   key: 'fishing.barrel_found',
   isInteractive: true,
   seedScope: 'player',
-  cooldownBuckets: 2,
-  probability: () => 0,
+  cooldownBuckets: inBuckets('3d'),
+  probability: () => 0.1,
 
   initialStep: 'openOrLeave',
   steps: {

--- a/apps/bot/src/domains/event/generators/passive/calm-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/calm-sea.ts
@@ -1,4 +1,5 @@
 import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
+import { inBuckets } from '../../engine/bucket.js';
 import type { PassiveGenerator } from '../../types.js';
 import { computeNothing, isSea } from '../utils.js';
 
@@ -7,7 +8,7 @@ export const calmSea: PassiveGenerator = {
   isInteractive: false,
   seedScope: 'zone',
   conditions: (ctx) => isSea(ctx.zone),
-  cooldownBuckets: 4,
+  cooldownBuckets: inBuckets('1d'),
   probability: () => 0.15,
 
   // TODO: appliquer +1 moral via un effet `addMorale` quand morale est implémenté

--- a/apps/bot/src/domains/event/generators/passive/rough-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/rough-sea.ts
@@ -1,4 +1,5 @@
 import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
+import { inBuckets } from '../../engine/bucket.js';
 import type { PassiveGenerator } from '../../types.js';
 import { computeNothing, isSea } from '../utils.js';
 
@@ -7,7 +8,7 @@ export const roughSea: PassiveGenerator = {
   isInteractive: false,
   seedScope: 'zone',
   conditions: (ctx) => isSea(ctx.zone),
-  cooldownBuckets: 4,
+  cooldownBuckets: inBuckets('1d'),
   probability: () => 0.15,
 
   // TODO: appliquer -1 moral via un effet `addMorale` quand morale est implémenté

--- a/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
+++ b/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
@@ -1,5 +1,6 @@
 import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
 import { buildAssetUrl } from '../../../../shared/build-asset-url.js';
+import { inBuckets } from '../../engine/bucket.js';
 import type { PassiveGenerator } from '../../types.js';
 import { computeNothing, isSea } from '../utils.js';
 
@@ -8,7 +9,7 @@ export const seagullFlyby: PassiveGenerator = {
   isInteractive: false,
   seedScope: 'player',
   conditions: (ctx) => isSea(ctx.zone),
-  cooldownBuckets: 2,
+  cooldownBuckets: inBuckets('1d'),
   probability: () => 0.3,
 
   compute: computeNothing,

--- a/apps/bot/src/domains/navigation/world.ts
+++ b/apps/bot/src/domains/navigation/world.ts
@@ -1,5 +1,7 @@
 import type { ResourceName, Island, Sea } from '@one-piece/db';
 
+import { inBuckets } from '../event/engine/bucket.js';
+
 type TravelRequirement = { kind: 'item'; name: ResourceName };
 
 type TravelModifier = { kind: 'no_navigator'; multiplier: number };
@@ -14,34 +16,34 @@ type Edge = {
 };
 
 export const ZONE_GRAPH = [
-  { from: 'foosha', to: 'loguetown', via: 'sea_east_blue', baseDurationBuckets: 6 },
-  { from: 'loguetown', to: 'reverse_mountain', via: 'sea_east_blue', baseDurationBuckets: 8 },
+  { from: 'foosha', to: 'loguetown', via: 'sea_east_blue', baseDurationBuckets: inBuckets('2h') },
+  { from: 'loguetown', to: 'reverse_mountain', via: 'sea_east_blue', baseDurationBuckets: inBuckets('2h') },
   {
     from: 'reverse_mountain',
     to: 'whisky_peak',
     via: 'sea_paradise',
-    baseDurationBuckets: 12,
+    baseDurationBuckets: inBuckets('6h'),
     requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
   {
     from: 'whisky_peak',
     to: 'little_garden',
     via: 'sea_paradise',
-    baseDurationBuckets: 18,
+    baseDurationBuckets: inBuckets('6h'),
     requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
   {
     from: 'little_garden',
     to: 'drum',
     via: 'sea_paradise',
-    baseDurationBuckets: 25,
+    baseDurationBuckets: inBuckets('8h'),
     requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
   {
     from: 'drum',
     to: 'alabasta',
     via: 'sea_paradise',
-    baseDurationBuckets: 30,
+    baseDurationBuckets: inBuckets('5h'),
     requirements: [{ kind: 'item', name: 'Log Pose' }],
   },
 ] satisfies Array<Edge>;


### PR DESCRIPTION
- Ajout de l'util `inBuckets(duration: string): number`
- Permet d'avoir un nombre de buckets directement en parlant en heure
- Accepte `nombre` `m | h | d` (minutes, hours ,days)
- Check tout seul si la valeur est bien sous la forme `nombre``m | h | d`  via une REGEX sinon ça THROW une error au lancement de l'application
- Remplacement de tous les endroits où on utilisait des nombres de buckets à la main, par `inBuckets`

### Exemples :
<img width="163" height="44" alt="image" src="https://github.com/user-attachments/assets/c9c40646-8db4-448a-a5c1-7be603c71ec7" />
<br>
<img width="166" height="34" alt="image" src="https://github.com/user-attachments/assets/8789aa03-ce12-446c-ad39-a3a10f354c13" />
<img width="428" height="42" alt="image" src="https://github.com/user-attachments/assets/22ae5aeb-cac3-4e68-9687-212275aedac7" />


<img width="483" height="30" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/73437fbc-7a7d-4b60-bf8f-e118a8d5f3a9" />
<img width="66" height="20" alt="2 16 192" src="https://github.com/user-attachments/assets/0e7e084c-0590-4d90-84bb-ff4b63eee321" />