### PR TITLE
Renommer les keys d'events en camelCase + finder fuzzy pour force-event

### DIFF
--- a/apps/bot/src/domains/_dev/commands/force-event.ts
+++ b/apps/bot/src/domains/_dev/commands/force-event.ts
@@ -7,7 +7,7 @@ import { getNowBucketId } from '../../event/engine/bucket.js';
 import { buildGeneratorContext, fetchGeneratorContextData } from '../../event/engine/context-builders.js';
 import { recordInteractive, recordPassive } from '../../event/engine/record-event.js';
 import { createRngForGenerator } from '../../event/engine/rng.js';
-import { findGeneratorByKeyOrThrow } from '../../event/generators/registry.js';
+import { findGeneratorByFuzzyKeyOrThrow } from '../../event/generators/registry.js';
 import { resolveTargetPlayer } from '../../player/index.js';
 import * as playerRepository from '../../player/repository.js';
 
@@ -21,7 +21,7 @@ export const forceEventCommand: Command = {
       throw new ValidationError('Usage: !force-event <@user> <clé évènement>');
     }
 
-    const gen = findGeneratorByKeyOrThrow(eventKey);
+    const gen = findGeneratorByFuzzyKeyOrThrow(eventKey);
 
     const bucketId = getNowBucketId();
 

--- a/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
+++ b/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
@@ -3,7 +3,7 @@ import type { GeneratorContext, InteractiveGenerator, Resolution, Rng } from '..
 import { getRandomIntBetween } from '../utils.js';
 
 export const barrelFound: InteractiveGenerator = {
-  key: 'fishing.barrel_found',
+  key: 'barrelFound',
   isInteractive: true,
   seedScope: 'player',
   cooldownBuckets: 2,
@@ -26,7 +26,7 @@ function openBarrel(_ctx: GeneratorContext, rng: Rng): Resolution {
   return {
     embed: buildOpEmbed('success').setTitle(`Tu trouves ${berries} berries dans le baril.`),
     effects: [{ type: 'addBerries', amount: BigInt(berries) }],
-    resolutionType: 'fishing.barrel_found.opened',
+    resolutionType: 'barrelFound.opened',
   };
 }
 
@@ -34,6 +34,6 @@ function leaveBarrel(): Resolution {
   return {
     embed: buildOpEmbed('info').setTitle('Tu passes ton chemin.'),
     effects: [],
-    resolutionType: 'fishing.barrel_found.left',
+    resolutionType: 'barrelFound.left',
   };
 }

--- a/apps/bot/src/domains/event/generators/passive/calm-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/calm-sea.ts
@@ -3,7 +3,7 @@ import type { PassiveGenerator } from '../../types.js';
 import { computeNothing, isSea } from '../utils.js';
 
 export const calmSea: PassiveGenerator = {
-  key: 'passive.calm_sea',
+  key: 'calmSea',
   isInteractive: false,
   seedScope: 'zone',
   conditions: (ctx) => isSea(ctx.zone),

--- a/apps/bot/src/domains/event/generators/passive/peaceful-east-blue.ts
+++ b/apps/bot/src/domains/event/generators/passive/peaceful-east-blue.ts
@@ -4,7 +4,7 @@ import type { PassiveGenerator } from '../../types.js';
 import { computeNothing } from '../utils.js';
 
 export const peacefulEastBlue: PassiveGenerator = {
-  key: 'passive.peaceful_east_blue',
+  key: 'peacefulEastBlue',
   isInteractive: false,
   seedScope: 'player',
   conditions: (ctx) => ctx.zone === 'sea_east_blue',

--- a/apps/bot/src/domains/event/generators/passive/rough-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/rough-sea.ts
@@ -3,7 +3,7 @@ import type { PassiveGenerator } from '../../types.js';
 import { computeNothing, isSea } from '../utils.js';
 
 export const roughSea: PassiveGenerator = {
-  key: 'passive.rough_sea',
+  key: 'roughSea',
   isInteractive: false,
   seedScope: 'zone',
   conditions: (ctx) => isSea(ctx.zone),

--- a/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
+++ b/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
@@ -4,7 +4,7 @@ import type { PassiveGenerator } from '../../types.js';
 import { computeNothing, isSea } from '../utils.js';
 
 export const seagullFlyby: PassiveGenerator = {
-  key: 'passive.seagull_flyby',
+  key: 'seagullFlyby',
   isInteractive: false,
   seedScope: 'player',
   conditions: (ctx) => isSea(ctx.zone),

--- a/apps/bot/src/domains/event/generators/registry.ts
+++ b/apps/bot/src/domains/event/generators/registry.ts
@@ -1,4 +1,4 @@
-import { NotFoundError } from '../../../discord/errors.js';
+import { NotFoundError, ValidationError } from '../../../discord/errors.js';
 import type { EventGenerator } from '../types.js';
 
 import { interactiveGenerators } from './interactive/registry.js';
@@ -12,4 +12,18 @@ export function findGeneratorByKeyOrThrow(eventKey: string): EventGenerator {
   const generator = allGenerators.find((gen) => gen.key === eventKey);
   if (!generator) throw new NotFoundError(`Générateur introuvable pour l'évènement: ${eventKey}`);
   return generator;
+}
+
+export function findGeneratorByFuzzyKeyOrThrow(query: string): EventGenerator {
+  const lower = query.toLowerCase();
+  const exact = allGenerators.find((gen) => gen.key.toLowerCase() === lower);
+  if (exact) return exact;
+
+  const matches = allGenerators.filter((gen) => gen.key.toLowerCase().includes(lower));
+  if (matches.length === 1) return matches[0]!;
+  if (matches.length > 1) {
+    const keys = matches.map((gen) => gen.key).join(', ');
+    throw new ValidationError(`Plusieurs générateurs matchent "${query}": ${keys}`);
+  }
+  throw new NotFoundError(`Générateur introuvable pour l'évènement: ${query}`);
 }

--- a/apps/bot/src/domains/event/recap/build-recap-view.ts
+++ b/apps/bot/src/domains/event/recap/build-recap-view.ts
@@ -26,7 +26,7 @@ export async function buildRecapView(player: Player): Promise<View> {
     return {
       embeds: [
         buildOpEmbed('info')
-          .setTitle(`Vous n'avez ucun évènement à consulter.`)
+          .setTitle(`Vous n'avez aucun évènement à consulter.`)
           .setDescription('Revenez plus tard.')
           .setFooter({ text: getRandomCalmTextByZone(player.currentZone) }),
       ],

--- a/apps/bot/src/domains/event/recap/build-recap-view.ts
+++ b/apps/bot/src/domains/event/recap/build-recap-view.ts
@@ -24,7 +24,12 @@ export async function buildRecapView(player: Player): Promise<View> {
       buildProfilButton(player.discordId, player.id, { label: 'Voir mon profil' }),
     );
     return {
-      embeds: [buildOpEmbed('info').setTitle('Vous êtes à jour').setDescription(getRandomCalmTextByZone(player.currentZone))],
+      embeds: [
+        buildOpEmbed('info')
+          .setTitle(`Vous n'avez ucun évènement à consulter.`)
+          .setDescription('Revenez plus tard.')
+          .setFooter({ text: getRandomCalmTextByZone(player.currentZone) }),
+      ],
       components: [profilRow],
     };
   }


### PR DESCRIPTION
## Résumé
- Renomme les `key` des générateurs d'events en camelCase et supprime les préfixes `passive.` / `fishing.` (redondants pour rien)
- Ajoute `findGeneratorByFuzzyKeyOrThrow` (case-insensitive + match partiel) utilisé par `!force-event` pour rendre la commande de debug plus facile à utiliser (!fe seagull) --> ça te met seagullFlyby