### PR TITLE
Add navigation services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,9 @@ Bot Discord autour de l'univers One Piece. Le joueur recrute un équipage, amél
 - Les erreurs : gérer aux frontières (entrée Discord, APIs externes, DB). Faire confiance au code interne.
 - **TODO** : tout code temporaire (test manuel, stub, placeholder, hack) doit être marqué `// TODO: <raison>`. Permet de le retrouver facilement (`rg TODO`) et de nettoyer avant merge.
 - **Repositories** : import en namespace, jamais nommé. Ex : `import * as playerRepository from '../player/repository.js'` puis `playerRepository.findById(...)`. Les fonctions du repo n'ont pas le suffixe d'entité (`findOrCreate`, pas `findOrCreatePlayer`) — le namespace porte déjà l'info.
+- **Signatures de fonctions** :
+  - **1–2 args métier** : positionnels, `options: OptionsType = {}` en dernier. Ex : `clearTravel(playerId, options)`.
+  - **3+ args métier** : un seul param object `{...}` typé via un `type FooParams = {...; options?: OptionsType}`. Ex : `completeTravel({ playerId, bucketId, rng, options })`.
 
 ## Structure
 

--- a/apps/bot/src/domains/event/engine/rng.ts
+++ b/apps/bot/src/domains/event/engine/rng.ts
@@ -77,3 +77,9 @@ export function pickRandomWithSeed<T>(seed: number, items: Array<T>): T {
   if (items.length === 0) throw new Error('pickRandomWithSeed: items is empty');
   return items[Math.floor(createRng(seed).next() * items.length)]!;
 }
+
+/** Tirage déterministe d'un élément en consommant un `Rng` existant. Équivalent de `lodash.sample`. */
+export function pickRandom<T>(rng: Rng, items: Array<T>): T {
+  if (items.length === 0) throw new Error('pickRandom: items is empty');
+  return items[Math.floor(rng.next() * items.length)]!;
+}

--- a/apps/bot/src/domains/history/types/index.ts
+++ b/apps/bot/src/domains/history/types/index.ts
@@ -1,6 +1,7 @@
 import type { CrewLog } from './crew.js';
 import type { FishingLog } from './fishing.js';
+import type { NavigationLog } from './navigation.js';
 import type { PlayerLog } from './player.js';
 import type { ShipLog } from './ship.js';
 
-export type Log = CrewLog | PlayerLog | FishingLog | ShipLog;
+export type Log = CrewLog | PlayerLog | FishingLog | ShipLog | NavigationLog;

--- a/apps/bot/src/domains/history/types/navigation.ts
+++ b/apps/bot/src/domains/history/types/navigation.ts
@@ -1,0 +1,18 @@
+import type { Island, Sea } from '@one-piece/db';
+
+type TravelPayloadBase = {
+  from: Sea;
+  actualDurationBuckets: number;
+};
+
+type TravelArrivedLog = {
+  type: 'travel.arrived';
+  payload: TravelPayloadBase & { to: Island };
+};
+
+type TravelDriftedLog = {
+  type: 'travel.drifted';
+  payload: TravelPayloadBase & { intendedTo: Island; actualTo: Island };
+};
+
+export type NavigationLog = TravelArrivedLog | TravelDriftedLog;

--- a/apps/bot/src/domains/navigation/services/complete-travel.ts
+++ b/apps/bot/src/domains/navigation/services/complete-travel.ts
@@ -1,0 +1,74 @@
+import { db, type DbOrTransaction, type Island } from '@one-piece/db';
+
+import { ValidationError } from '../../../discord/errors.js';
+import type { ClientOptions } from '../../../shared/types.js';
+import { isSea } from '../../event/generators/utils.js';
+import type { Rng } from '../../event/types.js';
+import * as historyRepository from '../../history/index.js';
+import * as playerRepository from '../../player/repository.js';
+import * as resourceRepository from '../../resource/repository.js';
+import * as shipRepository from '../../ship/repository.js';
+import { computeDriftProbability, pickDriftIsland } from '../utils/index.js';
+
+import { recordZoneChange } from './record-zone-change.js';
+
+type CompleteTravelParams = {
+  playerId: number;
+  bucketId: number;
+  rng: Rng;
+  options?: ClientOptions;
+};
+
+type CompleteTravelResult = { arrivedZone: Island; drifted: boolean };
+
+/** Termine un voyage en cours et décide si on dérive ou pas */
+export async function completeTravel({ playerId, bucketId, rng, options = {} }: CompleteTravelParams): Promise<CompleteTravelResult> {
+  if (options.client) return runCompleteTravel(playerId, bucketId, rng, options.client);
+  return db.transaction((tx) => runCompleteTravel(playerId, bucketId, rng, tx));
+}
+
+async function runCompleteTravel(playerId: number, bucketId: number, rng: Rng, client: DbOrTransaction): Promise<CompleteTravelResult> {
+  const playerRow = await playerRepository.findByIdOrThrow(playerId, client, { forUpdate: true });
+  if (playerRow.travelTargetZone === null || playerRow.travelStartedBucket === null) {
+    throw new ValidationError('Aucun voyage en cours pour ce joueur.');
+  }
+  if (!isSea(playerRow.currentZone)) {
+    throw new ValidationError('Le joueur doit être en mer pour terminer un voyage.');
+  }
+
+  const intendedZone = playerRow.travelTargetZone;
+  const fromSea = playerRow.currentZone;
+  const actualDurationBuckets = bucketId - playerRow.travelStartedBucket;
+
+  const [ship, inventory] = await Promise.all([
+    shipRepository.findByPlayerIdOrThrow(playerId, client),
+    resourceRepository.getInventory(playerId, client),
+  ]);
+
+  const driftProbability = computeDriftProbability({ ship, inventory, fromSea, intendedZone });
+  const hasDrifted = rng.next() < driftProbability;
+  const arrivedZone = hasDrifted ? pickDriftIsland(fromSea, intendedZone, rng) : intendedZone;
+
+  await recordZoneChange({ playerId, newZone: arrivedZone, bucketId, options: { client } });
+  await playerRepository.clearTravel(playerId, { client });
+
+  if (hasDrifted) {
+    await historyRepository.appendHistory({
+      type: 'travel.drifted',
+      actorPlayerId: playerId,
+      bucketId,
+      payload: { from: fromSea, intendedTo: intendedZone, actualTo: arrivedZone, actualDurationBuckets },
+      client,
+    });
+  } else {
+    await historyRepository.appendHistory({
+      type: 'travel.arrived',
+      actorPlayerId: playerId,
+      bucketId,
+      payload: { from: fromSea, to: arrivedZone, actualDurationBuckets },
+      client,
+    });
+  }
+
+  return { arrivedZone, drifted: hasDrifted };
+}

--- a/apps/bot/src/domains/navigation/services/record-zone-change.ts
+++ b/apps/bot/src/domains/navigation/services/record-zone-change.ts
@@ -1,0 +1,30 @@
+import { db, type Zone } from '@one-piece/db';
+
+import { ValidationError } from '../../../discord/errors.js';
+import type { ClientOptions } from '../../../shared/types.js';
+import * as historyRepository from '../../history/index.js';
+import * as playerRepository from '../../player/repository.js';
+
+type RecordZoneChangeParams = {
+  playerId: number;
+  newZone: Zone;
+  bucketId: number;
+  options?: ClientOptions;
+};
+
+export async function recordZoneChange({ playerId, newZone, bucketId, options = {} }: RecordZoneChangeParams): Promise<void> {
+  const { client = db } = options;
+  const currentPlayer = await playerRepository.findByIdOrThrow(playerId, client);
+  const from = currentPlayer.currentZone;
+
+  if (from === newZone) throw new ValidationError('Vous êtes déjà à cet endroit');
+
+  await playerRepository.updateZone(playerId, newZone, client);
+  await historyRepository.appendHistory({
+    type: 'player.zone_changed',
+    actorPlayerId: playerId,
+    bucketId,
+    payload: { from, to: newZone },
+    client,
+  });
+}

--- a/apps/bot/src/domains/navigation/utils/compute-drift-probability.ts
+++ b/apps/bot/src/domains/navigation/utils/compute-drift-probability.ts
@@ -1,0 +1,56 @@
+import type { Island, Sea, Ship } from '@one-piece/db';
+import clamp from 'lodash/clamp.js';
+
+import type { Inventory } from '../../resource/types.js';
+import type { Edge, TravelModifier } from '../world.js';
+
+import { hasLogOrEternalPoseForIsland, findEdge } from './index.js';
+
+const DRIFT_BASE_PROBABILITY = 0.02;
+const DRIFT_MAX_PROBABILITY = 0.5;
+const DRIFT_SHIP_DAMAGE_WEIGHT = 0.3;
+const DRIFT_NO_POSE_PENALTY = 0.2;
+const MAX_SHIP_HP = 100;
+
+type ComputeDriftProbabilityParams = {
+  ship: Ship;
+  inventory: Inventory;
+  fromSea: Sea;
+  intendedZone: Island;
+};
+
+/**
+ * Retourne la probabilité que le joueur dérive et n'atteigne pas l'île visée.
+ * Combine : base + dégâts du navire + absence de Log/Eternal Pose + modificateurs propres à l'arête du graph.
+ */
+export function computeDriftProbability({ ship, inventory, fromSea, intendedZone }: ComputeDriftProbabilityParams): number {
+  const hasPose = hasLogOrEternalPoseForIsland(inventory, intendedZone);
+  // TODO: brancher hasNavigator quand le système de skills character existera
+  const modifierDriftDelta = sumModifierDriftDelta(findEdge(fromSea, intendedZone), { hasNavigator: false });
+
+  const damagePenalty = (1 - ship.hp / MAX_SHIP_HP) * DRIFT_SHIP_DAMAGE_WEIGHT;
+  const posePenalty = hasPose ? 0 : DRIFT_NO_POSE_PENALTY;
+
+  return clamp(DRIFT_BASE_PROBABILITY + damagePenalty + posePenalty + modifierDriftDelta, DRIFT_BASE_PROBABILITY, DRIFT_MAX_PROBABILITY);
+}
+
+type TravelModifierConditions = {
+  hasNavigator: boolean;
+};
+
+/** Somme des `driftDelta` des modifiers de l'arête qui s'appliquent (selon `conditions`). */
+function sumModifierDriftDelta(edge: Edge | undefined, conditions: TravelModifierConditions): number {
+  if (!edge?.modifiers) return 0;
+  return edge.modifiers
+    .filter((modifier) => isModifierApplicable(modifier, conditions))
+    .reduce((acc, modifier) => acc + (modifier.driftDelta ?? 0), 0);
+}
+
+/** True si le modifier doit être pris en compte au regard de l'état actuel du joueur. */
+function isModifierApplicable(modifier: TravelModifier, conditions: TravelModifierConditions): boolean {
+  switch (modifier.kind) {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- On a que no navigator pr l'instant // TODO: ENLEVER quand on en a plsr
+    case 'no_navigator':
+      return !conditions.hasNavigator;
+  }
+}

--- a/apps/bot/src/domains/navigation/utils/find-edge.ts
+++ b/apps/bot/src/domains/navigation/utils/find-edge.ts
@@ -1,0 +1,7 @@
+import type { Island, Sea } from '@one-piece/db';
+
+import { ZONE_GRAPH, type Edge } from '../world.js';
+
+export function findEdge(via: Sea, to: Island): Edge | undefined {
+  return ZONE_GRAPH.find((edge) => edge.via === via && edge.to === to);
+}

--- a/apps/bot/src/domains/navigation/utils/has-log-or-eternal-pose-for-island.ts
+++ b/apps/bot/src/domains/navigation/utils/has-log-or-eternal-pose-for-island.ts
@@ -1,0 +1,17 @@
+import type { Island, ResourceName } from '@one-piece/db';
+
+import type { Inventory } from '../../resource/types.js';
+
+const ETERNAL_POSE_BY_ISLAND: Partial<Record<Island, ResourceName>> = {
+  whisky_peak: 'Eternal Pose - Whisky Peak',
+  little_garden: 'Eternal Pose - Little Garden',
+  drum: 'Eternal Pose - Drum',
+  alabasta: 'Eternal Pose - Alabasta',
+};
+
+export function hasLogOrEternalPoseForIsland(inventory: Inventory, island: Island): boolean {
+  if (inventory.some((item) => item.name === 'Log Pose')) return true;
+  const eternalPose = ETERNAL_POSE_BY_ISLAND[island];
+  if (eternalPose === undefined) return false;
+  return inventory.some((item) => item.name === eternalPose);
+}

--- a/apps/bot/src/domains/navigation/utils/index.ts
+++ b/apps/bot/src/domains/navigation/utils/index.ts
@@ -1,0 +1,4 @@
+export { computeDriftProbability } from './compute-drift-probability.js';
+export { findEdge } from './find-edge.js';
+export { hasLogOrEternalPoseForIsland } from './has-log-or-eternal-pose-for-island.js';
+export { pickDriftIsland } from './pick-drift-island.js';

--- a/apps/bot/src/domains/navigation/utils/pick-drift-island.ts
+++ b/apps/bot/src/domains/navigation/utils/pick-drift-island.ts
@@ -1,0 +1,16 @@
+import type { Island, Sea } from '@one-piece/db';
+
+import { pickRandom } from '../../event/engine/rng.js';
+import type { Rng } from '../../event/types.js';
+import { ZONE_GRAPH } from '../world.js';
+
+/**
+ * Choisit aléatoirement une île d'arrivée alternative quand le joueur dérive :
+ * une autre île accessible via la même mer `fromSea`. Fallback à `intendedZone` si aucune autre option.
+ */
+export function pickDriftIsland(fromSea: Sea, intendedZone: Island, rng: Rng): Island {
+  const candidates = ZONE_GRAPH.filter((edge) => edge.via === fromSea && edge.to !== intendedZone).map((edge) => edge.to);
+  if (candidates.length === 0) return intendedZone;
+
+  return pickRandom(rng, candidates);
+}

--- a/apps/bot/src/domains/navigation/world.ts
+++ b/apps/bot/src/domains/navigation/world.ts
@@ -2,9 +2,17 @@ import type { ResourceName, Island, Sea } from '@one-piece/db';
 
 type TravelRequirement = { kind: 'item'; name: ResourceName };
 
-type TravelModifier = { kind: 'no_navigator'; multiplier: number };
+export type TravelModifierKind = 'no_navigator';
 
-type Edge = {
+export type TravelModifier = {
+  kind: TravelModifierKind;
+  /** Multiplicateur (%) de durée du voyage. */
+  durationMultiplier?: number;
+  /** Ajout à la probabilité de dérive */
+  driftDelta?: number;
+};
+
+export type Edge = {
   from: Island;
   to: Island;
   via: Sea;

--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -2,6 +2,7 @@ import { db, player, type DbOrTransaction, type Player, type Zone } from '@one-p
 import { eq } from 'drizzle-orm';
 
 import { NotFoundError } from '../../discord/errors.js';
+import type { ClientOptions } from '../../shared/types.js';
 import { getNowBucketId } from '../event/engine/bucket.js';
 
 type FindByIdOptions = {
@@ -42,6 +43,14 @@ export async function updateName(playerId: number, name: string, client: DbOrTra
 
 export async function updateZone(playerId: number, zone: Zone, client: DbOrTransaction = db): Promise<void> {
   await client.update(player).set({ currentZone: zone }).where(eq(player.id, playerId));
+}
+
+export async function clearTravel(playerId: number, options: ClientOptions = {}): Promise<void> {
+  const { client = db } = options;
+  await client
+    .update(player)
+    .set({ travelTargetZone: null, travelStartedBucket: null, travelEtaBucket: null })
+    .where(eq(player.id, playerId));
 }
 export async function updateCrewName(playerId: number, crewName: string, client: DbOrTransaction = db): Promise<Player> {
   const [row] = await client.update(player).set({ crewName }).where(eq(player.id, playerId)).returning();

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -1,11 +1,9 @@
-import { db, type DbOrTransaction, type Player, type Zone } from '@one-piece/db';
+import { db, type Player } from '@one-piece/db';
 
-import { ValidationError } from '../../discord/errors.js';
 import { sanitizeName } from '../../shared/sanitize-name.js';
 import * as characterRepository from '../character/repository.js';
 import { getLatestProcessableBucket } from '../event/engine/bucket.js';
 import * as eventRepository from '../event/repository.js';
-import * as historyRepository from '../history/index.js';
 import { findOrCreateShip } from '../ship/service.js';
 
 import { assertNameNotEmpty, assertNameWithinMaxLength } from './guards/index.js';
@@ -55,20 +53,4 @@ export async function isPlayerUpToDate(playerId: number): Promise<boolean> {
   const interactivePending = await eventRepository.findFirstInteractivePending(playerId);
 
   return interactivePending === null;
-}
-
-export async function recordZoneChange(playerId: number, newZone: Zone, bucketId: number, client: DbOrTransaction = db): Promise<void> {
-  const currentPlayer = await playerRepository.findByIdOrThrow(playerId, client);
-  const from = currentPlayer.currentZone;
-
-  if (from === newZone) throw new ValidationError('Vous êtes déjà à cet endroit');
-
-  await playerRepository.updateZone(playerId, newZone, client);
-  await historyRepository.appendHistory({
-    type: 'player.zone_changed',
-    actorPlayerId: playerId,
-    bucketId,
-    payload: { from, to: newZone },
-    client,
-  });
 }

--- a/apps/bot/src/shared/types.ts
+++ b/apps/bot/src/shared/types.ts
@@ -1,0 +1,3 @@
+import type { DbOrTransaction } from '@one-piece/db';
+
+export type ClientOptions = { client?: DbOrTransaction };

--- a/packages/db/src/domains/player/schema.ts
+++ b/packages/db/src/domains/player/schema.ts
@@ -5,6 +5,7 @@ import { MAX_CHARACTER_NAME_LENGTH, MAX_CREW_NAME_LENGTH } from '../../shared/co
 import { timestamps } from '../../shared/helpers.js';
 import { guild } from '../guild/schema.js';
 import { zoneEnum } from '../navigation/schema.js';
+import type { Island } from '../navigation/zones.js';
 
 export const player = pgTable('player', {
   id: serial('id').primaryKey(),
@@ -33,7 +34,7 @@ export const player = pgTable('player', {
   lastProcessedBucketId: integer('last_processed_bucket_id').notNull(),
   isAdmin: boolean('is_admin').notNull().default(false),
   currentZone: zoneEnum('current_zone').notNull().default('foosha'),
-  travelTargetZone: zoneEnum('travel_target_zone'),
+  travelTargetZone: zoneEnum('travel_target_zone').$type<Island>(),
   travelStartedBucket: integer('travel_started_bucket'),
   travelEtaBucket: integer('travel_eta_bucket'),
 });


### PR DESCRIPTION
## Résumé
- Ajoute le service `completeTravel` dans le domaine navigation : termine un voyage en cours, calcule la dérive (état du navire + Log/Eternal Pose + modifiers d'arête) et trace `travel.arrived` ou `travel.drifted`. Le service ouvre sa propre transaction si aucune n'est passée pour garantir l'atomicité des writes.
- Déplace `recordZoneChange` de `player/service.ts` vers `navigation/services/` (cohérence par domaine) et ajoute `clearTravel` dans le repo player.
- Extrait la logique de drift en utils dédiés (`computeDriftProbability`, `pickDriftIsland`, `findEdge`, `hasLogOrEternalPoseForIsland`) et ajoute `pickRandom` dans `rng.ts` (équivalent stateful de `pickRandomWithSeed`).
- Codifie la convention de signatures dans `CLAUDE.md` : 1–2 args positionnels + `options`, 3+ args via param object typé.
- Typage : `player.travelTargetZone` narrowé en `Island` côté Drizzle (`$type<Island>()`), ajout de `NavigationLog` à l'union `Log`, nouveau type partagé `ClientOptions`.
