### PR TITLE
218 repository player updatetraveltarget re routing en cours de voyage

### DIFF
--- a/apps/bot/src/domains/character/repository.ts
+++ b/apps/bot/src/domains/character/repository.ts
@@ -32,6 +32,7 @@ export async function getCharactersByPlayerId(playerId: number, client: DbOrTran
     .orderBy(desc(characterInstance.isCaptain), sql`${characterInstance.joinedCrewAt} asc nulls last`, asc(characterTemplate.name));
 }
 
+// TODO: multi-statement → service avec tx
 export async function createCharacterInstance(playerId: number, templateId: number): Promise<CharacterRow> {
   const [created] = await db
     .insert(characterInstance)
@@ -100,6 +101,7 @@ export async function getPlayerAsCharacterTemplate(): Promise<CharacterTemplate>
   return row;
 }
 
+// TODO: multi-statement → service avec tx
 export async function createPlayerAsCharacterInstance(
   playerId: number,
   nickname: string,
@@ -119,6 +121,7 @@ export async function createPlayerAsCharacterInstance(
   return row!;
 }
 
+// TODO: multi-statement → service avec tx
 export async function updatePlayerAsCharacterNickname(playerId: number, nickname: string, client: DbOrTransaction = db): Promise<void> {
   const playerAsCharacterTemplate = await getPlayerAsCharacterTemplate();
   await client

--- a/apps/bot/src/domains/event/generators/passive/calm-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/calm-sea.ts
@@ -1,6 +1,7 @@
 import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
+import { isSea } from '../../../navigation/utils/index.js';
 import type { PassiveGenerator } from '../../types.js';
-import { computeNothing, isSea } from '../utils.js';
+import { computeNothing } from '../utils.js';
 
 export const calmSea: PassiveGenerator = {
   key: 'calmSea',

--- a/apps/bot/src/domains/event/generators/passive/rough-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/rough-sea.ts
@@ -1,6 +1,7 @@
 import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
+import { isSea } from '../../../navigation/utils/index.js';
 import type { PassiveGenerator } from '../../types.js';
-import { computeNothing, isSea } from '../utils.js';
+import { computeNothing } from '../utils.js';
 
 export const roughSea: PassiveGenerator = {
   key: 'roughSea',

--- a/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
+++ b/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
@@ -1,7 +1,8 @@
 import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
 import { buildAssetUrl } from '../../../../shared/build-asset-url.js';
+import { isSea } from '../../../navigation/utils/index.js';
 import type { PassiveGenerator } from '../../types.js';
-import { computeNothing, isSea } from '../utils.js';
+import { computeNothing } from '../utils.js';
 
 export const seagullFlyby: PassiveGenerator = {
   key: 'seagullFlyby',

--- a/apps/bot/src/domains/event/generators/utils.ts
+++ b/apps/bot/src/domains/event/generators/utils.ts
@@ -1,13 +1,7 @@
-import { SEAS, type Sea, type Zone } from '@one-piece/db';
-
 import type { Rng } from '../types.js';
 
 export function computeNothing() {
   return { effects: [], state: {} };
-}
-
-export function isSea(zone: Zone): zone is Sea {
-  return (SEAS as ReadonlyArray<Zone>).includes(zone);
 }
 
 /** Entier dans [min, max] (bornes incluses) tiré depuis le rng fourni. */

--- a/apps/bot/src/domains/guild/repository.ts
+++ b/apps/bot/src/domains/guild/repository.ts
@@ -1,7 +1,7 @@
 import { db, guild, type Guild } from '@one-piece/db';
 import { eq } from 'drizzle-orm';
 
-// TODO: MOVE DANS UN SERVICE
+// TODO: multi-statement → service avec tx
 export async function findOrCreate(guildId: string, name: string): Promise<Guild> {
   const [existing] = await db.select().from(guild).where(eq(guild.id, guildId)).limit(1);
   if (existing?.name === name) return existing;

--- a/apps/bot/src/domains/history/types/navigation.ts
+++ b/apps/bot/src/domains/history/types/navigation.ts
@@ -15,4 +15,9 @@ type TravelDriftedLog = {
   payload: TravelPayloadBase & { intendedTo: Island; actualTo: Island };
 };
 
-export type NavigationLog = TravelArrivedLog | TravelDriftedLog;
+type TravelReroutedLog = {
+  type: 'travel.rerouted';
+  payload: { from: Island; originalTo: Island; newTo: Island };
+};
+
+export type NavigationLog = TravelArrivedLog | TravelDriftedLog | TravelReroutedLog;

--- a/apps/bot/src/domains/navigation/services/complete-travel.ts
+++ b/apps/bot/src/domains/navigation/services/complete-travel.ts
@@ -1,7 +1,6 @@
-import { db, type DbOrTransaction, type Island } from '@one-piece/db';
+import { type Island, type Transaction } from '@one-piece/db';
 
 import { ValidationError } from '../../../discord/errors.js';
-import type { ClientOptions } from '../../../shared/types.js';
 import { isSea } from '../../event/generators/utils.js';
 import type { Rng } from '../../event/types.js';
 import * as historyRepository from '../../history/index.js';
@@ -16,19 +15,14 @@ type CompleteTravelParams = {
   playerId: number;
   bucketId: number;
   rng: Rng;
-  options?: ClientOptions;
+  tx: Transaction;
 };
 
 type CompleteTravelResult = { arrivedZone: Island; drifted: boolean };
 
 /** Termine un voyage en cours et décide si on dérive ou pas */
-export async function completeTravel({ playerId, bucketId, rng, options = {} }: CompleteTravelParams): Promise<CompleteTravelResult> {
-  if (options.client) return runCompleteTravel(playerId, bucketId, rng, options.client);
-  return db.transaction((tx) => runCompleteTravel(playerId, bucketId, rng, tx));
-}
-
-async function runCompleteTravel(playerId: number, bucketId: number, rng: Rng, client: DbOrTransaction): Promise<CompleteTravelResult> {
-  const playerRow = await playerRepository.findByIdOrThrow(playerId, client, { forUpdate: true });
+export async function completeTravel({ playerId, bucketId, rng, tx }: CompleteTravelParams): Promise<CompleteTravelResult> {
+  const playerRow = await playerRepository.findByIdOrThrow(playerId, tx, { forUpdate: true });
   if (playerRow.travelTargetZone === null || playerRow.travelStartedBucket === null) {
     throw new ValidationError('Aucun voyage en cours pour ce joueur.');
   }
@@ -41,16 +35,16 @@ async function runCompleteTravel(playerId: number, bucketId: number, rng: Rng, c
   const actualDurationBuckets = bucketId - playerRow.travelStartedBucket;
 
   const [ship, inventory] = await Promise.all([
-    shipRepository.findByPlayerIdOrThrow(playerId, client),
-    resourceRepository.getInventory(playerId, client),
+    shipRepository.findByPlayerIdOrThrow(playerId, tx),
+    resourceRepository.getInventory(playerId, tx),
   ]);
 
   const driftProbability = computeDriftProbability({ ship, inventory, fromSea, intendedZone });
   const hasDrifted = rng.next() < driftProbability;
   const arrivedZone = hasDrifted ? pickDriftIsland(fromSea, intendedZone, rng) : intendedZone;
 
-  await recordZoneChange({ playerId, newZone: arrivedZone, bucketId, options: { client } });
-  await playerRepository.clearTravel(playerId, { client });
+  await recordZoneChange({ playerId, newZone: arrivedZone, bucketId, tx });
+  await playerRepository.clearTravel(playerId, { client: tx });
 
   if (hasDrifted) {
     await historyRepository.appendHistory({
@@ -58,7 +52,7 @@ async function runCompleteTravel(playerId: number, bucketId: number, rng: Rng, c
       actorPlayerId: playerId,
       bucketId,
       payload: { from: fromSea, intendedTo: intendedZone, actualTo: arrivedZone, actualDurationBuckets },
-      client,
+      client: tx,
     });
   } else {
     await historyRepository.appendHistory({
@@ -66,7 +60,7 @@ async function runCompleteTravel(playerId: number, bucketId: number, rng: Rng, c
       actorPlayerId: playerId,
       bucketId,
       payload: { from: fromSea, to: arrivedZone, actualDurationBuckets },
-      client,
+      client: tx,
     });
   }
 

--- a/apps/bot/src/domains/navigation/services/complete-travel.ts
+++ b/apps/bot/src/domains/navigation/services/complete-travel.ts
@@ -1,13 +1,12 @@
 import { type Island, type Transaction } from '@one-piece/db';
 
 import { ValidationError } from '../../../discord/errors.js';
-import { isSea } from '../../event/generators/utils.js';
 import type { Rng } from '../../event/types.js';
 import * as historyRepository from '../../history/index.js';
 import * as playerRepository from '../../player/repository.js';
 import * as resourceRepository from '../../resource/repository.js';
 import * as shipRepository from '../../ship/repository.js';
-import { computeDriftProbability, pickDriftIsland } from '../utils/index.js';
+import { computeDriftProbability, isSea, pickDriftIsland } from '../utils/index.js';
 
 import { recordZoneChange } from './record-zone-change.js';
 

--- a/apps/bot/src/domains/navigation/services/record-zone-change.ts
+++ b/apps/bot/src/domains/navigation/services/record-zone-change.ts
@@ -1,7 +1,6 @@
-import { db, type Zone } from '@one-piece/db';
+import { type Transaction, type Zone } from '@one-piece/db';
 
 import { ValidationError } from '../../../discord/errors.js';
-import type { ClientOptions } from '../../../shared/types.js';
 import * as historyRepository from '../../history/index.js';
 import * as playerRepository from '../../player/repository.js';
 
@@ -9,22 +8,21 @@ type RecordZoneChangeParams = {
   playerId: number;
   newZone: Zone;
   bucketId: number;
-  options?: ClientOptions;
+  tx: Transaction;
 };
 
-export async function recordZoneChange({ playerId, newZone, bucketId, options = {} }: RecordZoneChangeParams): Promise<void> {
-  const { client = db } = options;
-  const currentPlayer = await playerRepository.findByIdOrThrow(playerId, client);
+export async function recordZoneChange({ playerId, newZone, bucketId, tx }: RecordZoneChangeParams): Promise<void> {
+  const currentPlayer = await playerRepository.findByIdOrThrow(playerId, tx);
   const from = currentPlayer.currentZone;
 
   if (from === newZone) throw new ValidationError('Vous êtes déjà à cet endroit');
 
-  await playerRepository.updateZone(playerId, newZone, client);
+  await playerRepository.updateZone(playerId, newZone, tx);
   await historyRepository.appendHistory({
     type: 'player.zone_changed',
     actorPlayerId: playerId,
     bucketId,
     payload: { from, to: newZone },
-    client,
+    client: tx,
   });
 }

--- a/apps/bot/src/domains/navigation/services/update-travel-target.ts
+++ b/apps/bot/src/domains/navigation/services/update-travel-target.ts
@@ -1,0 +1,43 @@
+import { player, type Transaction } from '@one-piece/db';
+import { eq } from 'drizzle-orm';
+
+import { ValidationError } from '../../../discord/errors.js';
+import * as historyRepository from '../../history/index.js';
+import * as playerRepository from '../../player/repository.js';
+import { isSea } from '../utils/index.js';
+import type { Edge } from '../world.js';
+
+import { recordZoneChange } from './record-zone-change.js';
+
+type UpdateTravelTargetParams = {
+  playerId: number;
+  newEdge: Edge;
+  newEtaBucket: number;
+  bucketId: number;
+  tx: Transaction;
+};
+
+export async function updateTravelTarget({ playerId, newEdge, newEtaBucket, bucketId, tx }: UpdateTravelTargetParams): Promise<void> {
+  const playerRow = await playerRepository.findByIdOrThrow(playerId, tx, { forUpdate: true });
+  if (!isSea(playerRow.currentZone)) {
+    throw new ValidationError('Le joueur doit être en mer pour dévier.');
+  }
+  if (playerRow.travelTargetZone === null) {
+    throw new ValidationError('Aucun voyage en cours pour ce joueur.');
+  }
+  const originalTo = playerRow.travelTargetZone;
+
+  await tx.update(player).set({ travelTargetZone: newEdge.to, travelEtaBucket: newEtaBucket }).where(eq(player.id, playerId));
+
+  if (playerRow.currentZone !== newEdge.via) {
+    await recordZoneChange({ playerId, newZone: newEdge.via, bucketId, tx });
+  }
+
+  await historyRepository.appendHistory({
+    type: 'travel.rerouted',
+    actorPlayerId: playerId,
+    bucketId,
+    payload: { from: newEdge.from, originalTo, newTo: newEdge.to },
+    client: tx,
+  });
+}

--- a/apps/bot/src/domains/navigation/utils/index.ts
+++ b/apps/bot/src/domains/navigation/utils/index.ts
@@ -1,3 +1,4 @@
+export { isSea } from './is-sea.js';
 export { computeDriftProbability } from './compute-drift-probability.js';
 export { findEdge } from './find-edge.js';
 export { hasLogOrEternalPoseForIsland } from './has-log-or-eternal-pose-for-island.js';

--- a/apps/bot/src/domains/navigation/utils/is-sea.ts
+++ b/apps/bot/src/domains/navigation/utils/is-sea.ts
@@ -1,0 +1,6 @@
+import type { Zone, Sea } from '@one-piece/db';
+import { SEAS } from '@one-piece/db';
+
+export function isSea(zone: Zone): zone is Sea {
+  return (SEAS as ReadonlyArray<Zone>).includes(zone);
+}

--- a/apps/bot/src/domains/resource/repository.ts
+++ b/apps/bot/src/domains/resource/repository.ts
@@ -50,6 +50,7 @@ export async function findById(id: number): Promise<ResourceTemplate | undefined
   return row;
 }
 
+// TODO: multi-statement → service avec tx
 export async function debitResourceByName(
   playerId: number,
   name: ResourceName,


### PR DESCRIPTION
## Résumé
- Ajoute `updateTravelTarget` pour rerouter un voyage en mer vers une nouvelle destination sans réinitialiser `travel_started_bucket` (l'historique de durée reste continu depuis le départ initial), et trace l'event `travel.rerouted`.
- Force `tx: Transaction` obligatoire sur `completeTravel` et `recordZoneChange` (au lieu d'un `options.client` optionnel qui auto-wrap), l'atomicité est désormais garantie au compile-time, plus de risque d'oublier la tx.
- Déplace `isSea` de `event/generators/utils.ts` vers `navigation/utils/` (le domaine légitime), et met à jour les 3 callsites des passive generators
- Ajoute des TODO sur les fonctions de repo multi-statement (`character`, `guild`, `resource.debitResourceByName`) qui devraient être promues en service avec `tx` — à faire dans une PR dédiée.
