### PR TITLE
Implement navigation UI and starting point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ Bot Discord autour de l'univers One Piece. Le joueur recrute un équipage, amél
 
 - `type`, jamais `interface`
 - N'exporter un `type` que s'il est importé ailleurs
+- `Array<T>`, jamais `T[]` (ESLint actif)
+- Helpers et fonctions top-level : `function foo() {}`, pas `const foo = () => {}`
 - Pas de commentaires qui décrivent **ce que** fait le code — uniquement **pourquoi** quand le « pourquoi » est non évident
 - **YAGNI** (_You Aren't Gonna Need It_) : on n'ajoute pas une feature, une dep, un helper, un validator tant qu'un code actuel ne l'utilise pas. Pas d'abstractions spéculatives — 3 lignes similaires valent mieux qu'un helper prématuré.
 - Les erreurs : gérer aux frontières (entrée Discord, APIs externes, DB). Faire confiance au code interne.
@@ -27,6 +29,9 @@ Bot Discord autour de l'univers One Piece. Le joueur recrute un équipage, amél
 - **Signatures de fonctions** :
   - **1–2 args métier** : positionnels, `options: OptionsType = {}` en dernier. Ex : `clearTravel(playerId, options)`.
   - **3+ args métier** : un seul param object `{...}` typé via un `type FooParams = {...; options?: OptionsType}`. Ex : `completeTravel({ playerId, bucketId, rng, options })`.
+- **Handlers Discord** : `deferUpdate()` / `deferReply()` **avant** toute opération DB ou réseau (sinon l'interaction expire).
+- **Pas de logique métier dans `discord/`** : c'est un adaptateur (routage + formatage des messages/embeds). La logique vit dans `domains/`.
+- **Commandes** : flags sur `Command`. Par défaut, le routeur sync le joueur avant le handler — s'il a un interactif pending, ça bloque la commande (`OutOfSyncError`). `requiresSynchronization: false` opt-out des deux (sync + gate), pour `!recap`, `_info`, `_dev`. `requiresOpAdmin: true` exige `player.isAdmin` (cf `assertPlayerIsAdmin`). Détails : `docs/domains/event/recap-flow.md`.
 
 ## Structure
 

--- a/apps/bot/src/discord/branding.ts
+++ b/apps/bot/src/discord/branding.ts
@@ -1,11 +1,10 @@
 // TODO: Décider la bonne couleur et le bon nom pour le bot discord
 export const BOT_NAME = 'One Piece Bot';
-export const BOT_COLOR = 0x5284de;
 
 export const EMBED_COLORS = {
-  default: BOT_COLOR,
+  default: 0x99aab5,
   error: 0xed4245,
-  info: 0x99aab5,
+  info: 0x5284de,
   success: 0x57f287,
   warn: 0xfee75c,
 } as const;

--- a/apps/bot/src/discord/router.ts
+++ b/apps/bot/src/discord/router.ts
@@ -50,6 +50,10 @@ export async function routeMessage(message: Message): Promise<void> {
 
     const { player } = await findOrCreatePlayer(message.author.id, message.author.username, guild.id);
 
+    if (command.requiresOpAdmin) {
+      // assertPlayerIsAdmin(player); TODO: réactiver en prod
+    }
+
     if (command.requiresSynchronization !== false) {
       await autoSyncBeforeAction(message, player);
     }

--- a/apps/bot/src/discord/types.ts
+++ b/apps/bot/src/discord/types.ts
@@ -14,7 +14,7 @@ export type Command = {
   name: CommandName;
   handler: (ctx: CommandContext) => Promise<void>;
   requiresSynchronization?: boolean;
-  requiresAdmin?: boolean;
+  requiresOpAdmin?: boolean;
 };
 
 export type ButtonHandler = {

--- a/apps/bot/src/discord/utils/build-discord-timestamp.ts
+++ b/apps/bot/src/discord/utils/build-discord-timestamp.ts
@@ -1,0 +1,6 @@
+import { time, TimestampStyles, type TimestampStylesString } from 'discord.js';
+
+/** Construit un timestamp Discord `<t:TIMESTAMP:STYLE>` */
+export function buildDiscordTimestamp(date: Date, style: TimestampStylesString = TimestampStyles.RelativeTime): string {
+  return time(date, style);
+}

--- a/apps/bot/src/discord/utils/build-menu-buttons.ts
+++ b/apps/bot/src/discord/utils/build-menu-buttons.ts
@@ -16,7 +16,7 @@ export function buildMenuButtons(currentKey: string, ownerDiscordId: string, pla
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     buildProfilButton(ownerDiscordId, playerId, { disabled: currentKey === PROFIL_BUTTON_NAME }),
     buildShipButton(ownerDiscordId, playerId, { disabled: currentKey === SHIP_BUTTON_NAME }),
-    buildInventoryNavButton(ownerDiscordId, playerId, { disabled: currentKey === INVENTORY_BUTTON_NAME }),
     buildCrewNavButton(ownerDiscordId, playerId, { disabled: currentKey === CREW_BUTTON_NAME }),
+    buildInventoryNavButton(ownerDiscordId, playerId, { disabled: currentKey === INVENTORY_BUTTON_NAME }),
   );
 }

--- a/apps/bot/src/discord/utils/index.ts
+++ b/apps/bot/src/discord/utils/index.ts
@@ -2,6 +2,7 @@ export { assertGuildMemberIsAdmin } from './assert-guild-member-is-admin.js';
 export { assertInteractorIsTheOwner } from './assert-interactor-is-the-owner.js';
 export { buildBackAction, buildBackButton } from './build-back-action.js';
 export { buildCustomId } from './build-custom-id.js';
+export { buildDiscordTimestamp } from './build-discord-timestamp.js';
 export { buildMenuButtons } from './build-menu-buttons.js';
 export { buildOpEmbed } from './build-op-embed.js';
 export { buildPaginationButtons } from './build-pagination-buttons.js';

--- a/apps/bot/src/domains/_dev/commands/index.ts
+++ b/apps/bot/src/domains/_dev/commands/index.ts
@@ -36,4 +36,4 @@ export const devCommands = [
   upgradeShipCommand,
   dmCommand,
   showHistoryCommand,
-].map((cmd) => ({ ...cmd, requiresAdmin: true, requiresSynchronization: false }));
+].map((cmd) => ({ ...cmd, requiresOpAdmin: true, requiresSynchronization: false }));

--- a/apps/bot/src/domains/event/auto-sync-before-action.ts
+++ b/apps/bot/src/domains/event/auto-sync-before-action.ts
@@ -35,7 +35,7 @@ export async function autoSyncBeforeAction(message: Message, player: Player): Pr
       embeds: [
         buildOpEmbed('info').setDescription(
           // TODO: remplacer par le préfixe de la guild
-          `📜 Ton équipage a vécu ${eventCountText} ${elapsed}. Tape \`!recap\` pour les revivre.`,
+          `📜 Votre équipage a vécu ${eventCountText} ${elapsed}. Tapez \`!recap\` pour les revivre.`,
         ),
       ],
     });

--- a/apps/bot/src/domains/event/constants.ts
+++ b/apps/bot/src/domains/event/constants.ts
@@ -1,4 +1,5 @@
 export const EVENT_BUTTON_NAME = 'evt';
+export const EVENT_NEXT_BUTTON_NAME = 'evt-next';
 
 // TODO: ENLEVER CA, CETAIT A LANCIENNE
 export const EVENT_TYPES = {

--- a/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
+++ b/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
@@ -13,7 +13,7 @@ export const barrelFound: InteractiveGenerator = {
   initialStep: 'openOrLeave',
   steps: {
     openOrLeave: {
-      embed: () => buildOpEmbed('info').setTitle('Un baril flotte près du navire.'),
+      embed: () => buildOpEmbed('info').setTitle('Votre équipage a croisé un baril qui flottait.'),
       choices: () => [
         { id: 'open', label: 'Ouvrir', resolve: openBarrel },
         { id: 'leave', label: 'Laisser', resolve: leaveBarrel },
@@ -25,7 +25,7 @@ export const barrelFound: InteractiveGenerator = {
 function openBarrel(_ctx: GeneratorContext, rng: Rng): Resolution {
   const berries = getRandomIntBetween(rng, 100, 1000);
   return {
-    embed: buildOpEmbed('success').setTitle(`Tu trouves ${berries} berries dans le baril.`),
+    embed: buildOpEmbed('success').setTitle(`Vous avez trouvé ${berries} berries dans le baril.`),
     effects: [{ type: 'addBerries', amount: BigInt(berries) }],
     resolutionType: 'barrelFound.opened',
   };
@@ -33,7 +33,7 @@ function openBarrel(_ctx: GeneratorContext, rng: Rng): Resolution {
 
 function leaveBarrel(): Resolution {
   return {
-    embed: buildOpEmbed('info').setTitle('Tu passes ton chemin.'),
+    embed: buildOpEmbed('info').setTitle('Vous avez passé votre chemin.'),
     effects: [],
     resolutionType: 'barrelFound.left',
   };

--- a/apps/bot/src/domains/event/generators/interactive/cheat-teleport.ts
+++ b/apps/bot/src/domains/event/generators/interactive/cheat-teleport.ts
@@ -1,0 +1,63 @@
+import { ZONE_LABELS, type Edge } from '@one-piece/db';
+
+import { buildOpEmbed } from '../../../../discord/utils/build-op-embed.js';
+import { computeTravelETA, findPossibleEdges, isSea } from '../../../navigation/utils/index.js';
+import type { GeneratorContext, InteractiveGenerator, Resolution } from '../../types.js';
+import { noProbability } from '../utils.js';
+
+export const cheatTeleport: InteractiveGenerator = {
+  key: 'cheatTeleport',
+  isInteractive: true,
+  seedScope: 'player',
+  probability: noProbability,
+
+  initialStep: 'pickDestination',
+  steps: {
+    pickDestination: {
+      embed: (_state, ctx) =>
+        buildOpEmbed('info')
+          .setTitle('🛠️ Cheat — choisir une destination')
+          .setDescription(
+            isSea(ctx.zone)
+              ? `Vous êtes en mer (${ZONE_LABELS[ctx.zone]}). Attendez d'arriver pour pouvoir repartir.`
+              : `Position actuelle : **${ZONE_LABELS[ctx.zone]}**`,
+          ),
+      choices: (_state, ctx) => {
+        if (isSea(ctx.zone)) {
+          return [{ id: 'cancel', label: 'Fermer', resolve: buildCancelResolution }];
+        }
+        const edges = findPossibleEdges(ctx.zone);
+        if (edges.length === 0) {
+          return [{ id: 'cancel', label: 'Aucune destination depuis ici', resolve: buildCancelResolution }];
+        }
+        return edges.map((edge) => ({
+          id: edge.to,
+          label: ZONE_LABELS[edge.to],
+          resolve: (resolveCtx: GeneratorContext) => buildStartTravelResolution(resolveCtx, edge),
+        }));
+      },
+    },
+  },
+};
+
+function buildStartTravelResolution(ctx: GeneratorContext, edge: Edge): Resolution {
+  const etaBucket = computeTravelETA({
+    edge,
+    ship: ctx.ship,
+    crew: ctx.crew.members,
+    startedBucket: ctx.bucketId,
+  });
+  return {
+    embed: buildOpEmbed('success').setTitle(`🚢 Cap sur ${ZONE_LABELS[edge.to]}.`),
+    effects: [{ type: 'startTravel', edge, etaBucket }],
+    resolutionType: 'cheatTeleport.started',
+  };
+}
+
+function buildCancelResolution(): Resolution {
+  return {
+    embed: buildOpEmbed('info').setTitle('Annulé.'),
+    effects: [],
+    resolutionType: 'cheatTeleport.cancel',
+  };
+}

--- a/apps/bot/src/domains/event/generators/interactive/cheat-teleport.ts
+++ b/apps/bot/src/domains/event/generators/interactive/cheat-teleport.ts
@@ -15,16 +15,14 @@ export const cheatTeleport: InteractiveGenerator = {
   steps: {
     pickDestination: {
       embed: (_state, ctx) =>
-        buildOpEmbed('info')
-          .setTitle('🛠️ Cheat — choisir une destination')
-          .setDescription(
-            isSea(ctx.zone)
-              ? `Vous êtes en mer (${ZONE_LABELS[ctx.zone]}). Attendez d'arriver pour pouvoir repartir.`
-              : `Position actuelle : **${ZONE_LABELS[ctx.zone]}**`,
-          ),
+        buildOpEmbed('info').setDescription(
+          isSea(ctx.zone)
+            ? `Vous êtes déjà en mer (${ZONE_LABELS[ctx.zone]}).\nOù souhaitez-vous aller ?`
+            : `Vous êtes à : **${ZONE_LABELS[ctx.zone]}**\nOù souhaitez-vous aller ?`,
+        ),
       choices: (_state, ctx) => {
         if (isSea(ctx.zone)) {
-          return [{ id: 'cancel', label: 'Fermer', resolve: buildCancelResolution }];
+          return [{ id: 'cancel', label: 'Rester où je suis', resolve: buildCancelResolution }];
         }
         const edges = findPossibleEdges(ctx.zone);
         if (edges.length === 0) {
@@ -32,7 +30,7 @@ export const cheatTeleport: InteractiveGenerator = {
         }
         return edges.map((edge) => ({
           id: edge.to,
-          label: ZONE_LABELS[edge.to],
+          label: `Partir vers ${ZONE_LABELS[edge.to]}`,
           resolve: (resolveCtx: GeneratorContext) => buildStartTravelResolution(resolveCtx, edge),
         }));
       },

--- a/apps/bot/src/domains/event/generators/interactive/registry.ts
+++ b/apps/bot/src/domains/event/generators/interactive/registry.ts
@@ -1,5 +1,6 @@
 import type { InteractiveGenerator } from '../../types.js';
 
 import { barrelFound } from './barrel-found.js';
+import { cheatTeleport } from './cheat-teleport.js';
 
-export const interactiveGenerators: Array<InteractiveGenerator> = [barrelFound];
+export const interactiveGenerators: Array<InteractiveGenerator> = [barrelFound, cheatTeleport];

--- a/apps/bot/src/domains/event/generators/passive/calm-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/calm-sea.ts
@@ -16,6 +16,6 @@ export const calmSea: PassiveGenerator = {
   compute: noCompute,
 
   render: () => {
-    return buildOpEmbed('info').setTitle("La mer est calme aujourd'hui. L'équipage se détend (+1 moral).");
+    return buildOpEmbed('info').setTitle("La mer a été calme. Votre équipage s'est détendu (+1 moral).");
   },
 };

--- a/apps/bot/src/domains/event/generators/passive/peaceful-east-blue.ts
+++ b/apps/bot/src/domains/event/generators/passive/peaceful-east-blue.ts
@@ -16,7 +16,7 @@ export const peacefulEastBlue: PassiveGenerator = {
   render: () => {
     return (
       buildOpEmbed('info')
-        .setTitle("East Blue s'étire sous un ciel paisible. L'équipage profite du paysage.")
+        .setTitle("East Blue s'est étendue sous un ciel paisible — votre équipage en a profité.")
         //TODO Changer le gif de golmon
         .setImage(buildAssetUrl('events/passive/peaceful-east-blue.webp'))
     );

--- a/apps/bot/src/domains/event/generators/passive/rough-sea.ts
+++ b/apps/bot/src/domains/event/generators/passive/rough-sea.ts
@@ -16,6 +16,6 @@ export const roughSea: PassiveGenerator = {
   compute: noCompute,
 
   render: () => {
-    return buildOpEmbed('info').setTitle('Une vague secoue le navire (-1 moral).');
+    return buildOpEmbed('info').setTitle('Une vague a secoué le navire (-1 moral).');
   },
 };

--- a/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
+++ b/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
@@ -16,8 +16,6 @@ export const seagullFlyby: PassiveGenerator = {
   compute: noCompute,
 
   render: () => {
-    return buildOpEmbed('info')
-      .setTitle('Une mouette passe au-dessus du navire.')
-      .setImage(buildAssetUrl('events/passive/seagull-flyby.webp'));
+    return buildOpEmbed('info').setTitle('Une mouette a survolé le navire.').setImage(buildAssetUrl('events/passive/seagull-flyby.webp'));
   },
 };

--- a/apps/bot/src/domains/event/interactions/event-choice-button.ts
+++ b/apps/bot/src/domains/event/interactions/event-choice-button.ts
@@ -1,8 +1,9 @@
 import { db } from '@one-piece/db';
-import type { ButtonInteraction } from 'discord.js';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type ButtonInteraction } from 'discord.js';
 
+import { PAGINATION } from '../../../discord/constants.js';
 import { InternalError } from '../../../discord/errors.js';
-import type { ButtonHandler } from '../../../discord/types.js';
+import type { ButtonHandler, View } from '../../../discord/types.js';
 import { parseBigintArg } from '../../../discord/utils/index.js';
 import * as historyRepository from '../../history/index.js';
 import * as playerRepository from '../../player/repository.js';
@@ -11,9 +12,12 @@ import { applyEffects } from '../effects/apply-effects.js';
 import { getNowBucketId } from '../engine/bucket.js';
 import { buildGeneratorContext, fetchGeneratorContextData } from '../engine/context-builders.js';
 import { createRngForGenerator } from '../engine/rng.js';
+import { synchronizePlayer } from '../engine/synchronize-player.js';
 import { findGeneratorByKeyOrThrow } from '../generators/registry.js';
 import { buildRecapView } from '../recap/build-recap-view.js';
 import * as eventRepository from '../repository.js';
+import type { Resolution } from '../types.js';
+import { buildEventNextCustomId } from '../utils/build-event-custom-id.js';
 
 export const eventChoiceButtonHandler: ButtonHandler = {
   name: EVENT_BUTTON_NAME,
@@ -33,7 +37,7 @@ export const eventChoiceButtonHandler: ButtonHandler = {
     if (!generator.isInteractive) {
       const player = await playerRepository.findByIdOrThrow(instance.playerId);
       await eventRepository.deleteById(instance.id);
-      await interaction.editReply(await buildRecapView(player));
+      await interaction.editReply(await buildRecapView(player, true));
       return;
     }
 
@@ -71,7 +75,19 @@ export const eventChoiceButtonHandler: ButtonHandler = {
       return;
     }
 
-    const nextView = await buildRecapView(result.player);
-    await interaction.editReply({ embeds: [result.resolution.embed, ...nextView.embeds], components: nextView.components });
+    await synchronizePlayer(result.player.id);
+
+    await interaction.editReply(buildResolutionView(result.resolution, result.player.discordId));
   },
 };
+
+function buildResolutionView(resolution: Resolution, ownerDiscordId: string): View {
+  const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildEventNextCustomId(ownerDiscordId))
+      .setEmoji(PAGINATION.next.emoji)
+      .setLabel(PAGINATION.next.label)
+      .setStyle(ButtonStyle.Primary),
+  );
+  return { embeds: [resolution.embed], components: [row] };
+}

--- a/apps/bot/src/domains/event/interactions/event-next-button.ts
+++ b/apps/bot/src/domains/event/interactions/event-next-button.ts
@@ -1,0 +1,24 @@
+import type { ButtonInteraction } from 'discord.js';
+
+import { NotFoundError } from '../../../discord/errors.js';
+import type { ButtonHandler } from '../../../discord/types.js';
+import { assertInteractorIsTheOwner, parseOwnerDiscordId } from '../../../discord/utils/index.js';
+import * as playerRepository from '../../player/repository.js';
+import { EVENT_NEXT_BUTTON_NAME } from '../constants.js';
+import { buildRecapView } from '../recap/build-recap-view.js';
+
+async function handle(interaction: ButtonInteraction, args: Array<string>): Promise<void> {
+  const ownerDiscordId = parseOwnerDiscordId(args[0]);
+  assertInteractorIsTheOwner(interaction, ownerDiscordId);
+  await interaction.deferUpdate();
+
+  const player = await playerRepository.findByDiscordId(ownerDiscordId);
+  if (!player) throw new NotFoundError('Joueur introuvable.');
+
+  await interaction.editReply(await buildRecapView(player, true));
+}
+
+export const eventNextButtonHandler: ButtonHandler = {
+  name: EVENT_NEXT_BUTTON_NAME,
+  handle,
+};

--- a/apps/bot/src/domains/event/interactions/registry.ts
+++ b/apps/bot/src/domains/event/interactions/registry.ts
@@ -1,6 +1,7 @@
 import type { ButtonHandler } from '../../../discord/types.js';
 
 import { eventChoiceButtonHandler } from './event-choice-button.js';
+import { eventNextButtonHandler } from './event-next-button.js';
 import { recapShortcutButtonHandler } from './recap-shortcut-button.js';
 
-export const eventButtonHandlers: Array<ButtonHandler> = [recapShortcutButtonHandler, eventChoiceButtonHandler];
+export const eventButtonHandlers: Array<ButtonHandler> = [recapShortcutButtonHandler, eventChoiceButtonHandler, eventNextButtonHandler];

--- a/apps/bot/src/domains/event/recap/build-recap-view.ts
+++ b/apps/bot/src/domains/event/recap/build-recap-view.ts
@@ -7,7 +7,7 @@ import { InternalError } from '../../../discord/errors.js';
 import type { View } from '../../../discord/types.js';
 import { buildOpEmbed } from '../../../discord/utils/index.js';
 import { buildProfilButton } from '../../player/build-profil-button.js';
-import { getNowBucketId } from '../engine/bucket.js';
+import { getNowBucketId, getStartDateOfBucket } from '../engine/bucket.js';
 import { buildGeneratorContext, fetchGeneratorContextData } from '../engine/context-builders.js';
 import { findGeneratorByKeyOrThrow } from '../generators/registry.js';
 import { getPendingEventsForPlayer, type PendingEventInstance } from '../repository.js';
@@ -16,22 +16,11 @@ import { buildEventInteractiveChoiceCustomId, buildEventPassiveNextCustomId } fr
 
 import { getRandomCalmTextByZone } from './get-random-calm-text-by-zone.js';
 
-export async function buildRecapView(player: Player): Promise<View> {
+export async function buildRecapView(player: Player, isContinuation = false): Promise<View> {
   const pendingEvents = await getPendingEventsForPlayer(player.id);
   const firstPendingEvent = pendingEvents[0];
   if (!firstPendingEvent) {
-    const profilRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      buildProfilButton(player.discordId, player.id, { label: 'Voir mon profil' }),
-    );
-    return {
-      embeds: [
-        buildOpEmbed('info')
-          .setTitle(`Vous n'avez aucun évènement à consulter.`)
-          .setDescription('Revenez plus tard.')
-          .setFooter({ text: getRandomCalmTextByZone(player.currentZone) }),
-      ],
-      components: [profilRow],
-    };
+    return buildEmptyView(player, isContinuation);
   }
 
   const generator = findGeneratorByKeyOrThrow(firstPendingEvent.eventKey);
@@ -42,8 +31,23 @@ export async function buildRecapView(player: Player): Promise<View> {
   return buildInteractiveView(generator, firstPendingEvent, player);
 }
 
+function buildEmptyView(player: Player, isContinuation: boolean): View {
+  const profilRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    buildProfilButton(player.discordId, player.id, { label: 'Voir mon profil' }),
+  );
+  const title = isContinuation ? "Plus d'évènements à consulter !" : "Aucun évènement à consulter pour l'instant.";
+  return {
+    embeds: [
+      buildOpEmbed('info')
+        .setTitle(title)
+        .setDescription(`*${getRandomCalmTextByZone(player.currentZone)}*`),
+    ],
+    components: [profilRow],
+  };
+}
+
 function buildPassiveView(generator: PassiveGenerator, instance: PendingEventInstance): View {
-  const embed = generator.render(instance.state);
+  const embed = generator.render(instance.state).setTimestamp(getStartDateOfBucket(instance.bucketId));
   const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
       .setCustomId(buildEventPassiveNextCustomId(instance.id))
@@ -61,7 +65,7 @@ async function buildInteractiveView(generator: InteractiveGenerator, instance: P
   if (!step) throw new InternalError(`Step introuvable: ${stepKey} pour ${generator.key}`);
 
   const ctx = await buildCtxForPlayer(player);
-  const embed = step.embed(instance.state, ctx);
+  const embed = step.embed(instance.state, ctx).setTimestamp(getStartDateOfBucket(instance.bucketId));
   const buttons = step
     .choices(instance.state, ctx)
     .map((choice) =>

--- a/apps/bot/src/domains/event/utils/build-event-custom-id.ts
+++ b/apps/bot/src/domains/event/utils/build-event-custom-id.ts
@@ -1,5 +1,5 @@
 import { buildCustomId } from '../../../discord/utils/index.js';
-import { EVENT_BUTTON_NAME } from '../constants.js';
+import { EVENT_BUTTON_NAME, EVENT_NEXT_BUTTON_NAME } from '../constants.js';
 
 /** @return evt:230212 */
 export function buildEventPassiveNextCustomId(eventInstanceId: bigint): string {
@@ -9,4 +9,9 @@ export function buildEventPassiveNextCustomId(eventInstanceId: bigint): string {
 /** @return evt:230213:attackCrocodile */
 export function buildEventInteractiveChoiceCustomId(eventInstanceId: bigint, choiceId: string): string {
   return buildCustomId(EVENT_BUTTON_NAME, eventInstanceId.toString(), choiceId);
+}
+
+/** @return evt-next:123456789 */
+export function buildEventNextCustomId(ownerDiscordId: string): string {
+  return buildCustomId(EVENT_NEXT_BUTTON_NAME, ownerDiscordId);
 }

--- a/apps/bot/src/domains/player/build-profil-view.ts
+++ b/apps/bot/src/domains/player/build-profil-view.ts
@@ -1,6 +1,5 @@
 import type { View } from '../../discord/types.js';
 import { buildMenuButtons, buildOpEmbed } from '../../discord/utils/index.js';
-import { getCrewDisplayName } from '../crew/utils/get-crew-display-name.js';
 import { formatBerry } from '../economy/utils/format-berry.js';
 
 import { PROFIL_BUTTON_NAME } from './constants.js';
@@ -15,7 +14,6 @@ export async function buildProfilView(playerId: number, ownerDiscordId: string):
     .addFields(
       { name: '💰 Bounty', value: formatBerry(player.bounty), inline: true },
       { name: '⚖️ Karma', value: `${player.karma} (${getKarmaGrade(player.karma)})`, inline: true },
-      { name: '🏴‍☠️ Équipage', value: getCrewDisplayName(player), inline: true },
     );
   return { embeds: [embed], components: [navRow] };
 }

--- a/apps/bot/src/domains/player/build-profil-view.ts
+++ b/apps/bot/src/domains/player/build-profil-view.ts
@@ -1,7 +1,11 @@
+import { ZONE_LABELS, type Player } from '@one-piece/db';
+import type { APIEmbedField } from 'discord.js';
+
 import type { View } from '../../discord/types.js';
-import { buildMenuButtons, buildOpEmbed } from '../../discord/utils/index.js';
+import { buildDiscordTimestamp, buildMenuButtons, buildOpEmbed } from '../../discord/utils/index.js';
 import { getCrewDisplayName } from '../crew/utils/get-crew-display-name.js';
 import { formatBerry } from '../economy/utils/format-berry.js';
+import { getStartDateOfBucket } from '../event/engine/bucket.js';
 
 import { PROFIL_BUTTON_NAME } from './constants.js';
 import { getKarmaGrade } from './karma.js';
@@ -16,6 +20,23 @@ export async function buildProfilView(playerId: number, ownerDiscordId: string):
       { name: '💰 Bounty', value: formatBerry(player.bounty), inline: true },
       { name: '⚖️ Karma', value: `${player.karma} (${getKarmaGrade(player.karma)})`, inline: true },
       { name: '🏴‍☠️ Équipage', value: getCrewDisplayName(player), inline: true },
+      ...buildLocationFields(player),
     );
   return { embeds: [embed], components: [navRow] };
+}
+
+function buildLocationFields(player: Player): Array<APIEmbedField> {
+  const positionField: APIEmbedField = { name: '📍 Position', value: ZONE_LABELS[player.currentZone], inline: true };
+  if (player.travelTargetZone === null || player.travelEtaBucket === null) {
+    return [positionField];
+  }
+  const arrivalAt = getStartDateOfBucket(player.travelEtaBucket);
+  return [
+    positionField,
+    {
+      name: '🚢 Destination',
+      value: `${ZONE_LABELS[player.travelTargetZone]}(~${buildDiscordTimestamp(arrivalAt)})`,
+      inline: true,
+    },
+  ];
 }

--- a/apps/bot/src/domains/player/build-profil-view.ts
+++ b/apps/bot/src/domains/player/build-profil-view.ts
@@ -1,11 +1,7 @@
-import { ZONE_LABELS, type Player } from '@one-piece/db';
-import type { APIEmbedField } from 'discord.js';
-
 import type { View } from '../../discord/types.js';
-import { buildDiscordTimestamp, buildMenuButtons, buildOpEmbed } from '../../discord/utils/index.js';
+import { buildMenuButtons, buildOpEmbed } from '../../discord/utils/index.js';
 import { getCrewDisplayName } from '../crew/utils/get-crew-display-name.js';
 import { formatBerry } from '../economy/utils/format-berry.js';
-import { getStartDateOfBucket } from '../event/engine/bucket.js';
 
 import { PROFIL_BUTTON_NAME } from './constants.js';
 import { getKarmaGrade } from './karma.js';
@@ -20,23 +16,6 @@ export async function buildProfilView(playerId: number, ownerDiscordId: string):
       { name: '💰 Bounty', value: formatBerry(player.bounty), inline: true },
       { name: '⚖️ Karma', value: `${player.karma} (${getKarmaGrade(player.karma)})`, inline: true },
       { name: '🏴‍☠️ Équipage', value: getCrewDisplayName(player), inline: true },
-      ...buildLocationFields(player),
     );
   return { embeds: [embed], components: [navRow] };
-}
-
-function buildLocationFields(player: Player): Array<APIEmbedField> {
-  const positionField: APIEmbedField = { name: '📍 Position', value: ZONE_LABELS[player.currentZone], inline: true };
-  if (player.travelTargetZone === null || player.travelEtaBucket === null) {
-    return [positionField];
-  }
-  const arrivalAt = getStartDateOfBucket(player.travelEtaBucket);
-  return [
-    positionField,
-    {
-      name: '🚢 Destination',
-      value: `${ZONE_LABELS[player.travelTargetZone]}(~${buildDiscordTimestamp(arrivalAt)})`,
-      inline: true,
-    },
-  ];
 }

--- a/apps/bot/src/domains/player/guards/assert-player-is-admin.ts
+++ b/apps/bot/src/domains/player/guards/assert-player-is-admin.ts
@@ -1,0 +1,9 @@
+import type { Player } from '@one-piece/db';
+
+import { ForbiddenError } from '../../../discord/errors.js';
+
+export function assertPlayerIsAdmin(player: Player): void {
+  if (!player.isAdmin) {
+    throw new ForbiddenError('Cette commande est réservée aux admins du jeu.');
+  }
+}

--- a/apps/bot/src/domains/player/guards/index.ts
+++ b/apps/bot/src/domains/player/guards/index.ts
@@ -1,2 +1,3 @@
 export { assertNameNotEmpty } from './assert-name-not-empty.js';
 export { assertNameWithinMaxLength } from './assert-name-within-max-length.js';
+export { assertPlayerIsAdmin } from './assert-player-is-admin.js';

--- a/apps/bot/src/domains/player/index.ts
+++ b/apps/bot/src/domains/player/index.ts
@@ -1,4 +1,4 @@
-export { findOrCreatePlayer, isPlayerUpToDate } from './service.js';
+export { findOrCreatePlayer } from './service.js';
 export { getKarmaGrade } from './karma.js';
 export * from './commands/index.js';
 export * from './interactions/index.js';

--- a/apps/bot/src/domains/player/service.ts
+++ b/apps/bot/src/domains/player/service.ts
@@ -2,8 +2,6 @@ import { db, type Player } from '@one-piece/db';
 
 import { sanitizeName } from '../../shared/sanitize-name.js';
 import * as characterRepository from '../character/repository.js';
-import { getLatestProcessableBucket } from '../event/engine/bucket.js';
-import * as eventRepository from '../event/repository.js';
 import { findOrCreateShip } from '../ship/service.js';
 
 import { assertNameNotEmpty, assertNameWithinMaxLength } from './guards/index.js';
@@ -40,17 +38,4 @@ export async function renamePlayer(playerId: number, rawName: string): Promise<P
     await characterRepository.updatePlayerAsCharacterNickname(playerId, sanitizedName, transaction);
     return updated;
   });
-}
-
-export async function isPlayerUpToDate(playerId: number): Promise<boolean> {
-  const player = await playerRepository.findByIdOrThrow(playerId);
-  const latestProcessableBucketId = getLatestProcessableBucket();
-
-  if (player.lastProcessedBucketId < latestProcessableBucketId) {
-    return false;
-  }
-
-  const interactivePending = await eventRepository.findFirstInteractivePending(playerId);
-
-  return interactivePending === null;
 }

--- a/apps/bot/src/domains/resource/inventory-view.ts
+++ b/apps/bot/src/domains/resource/inventory-view.ts
@@ -2,6 +2,7 @@ import type { Player } from '@one-piece/db';
 
 import type { View } from '../../discord/types.js';
 import { buildMenuButtons, buildOpEmbed, buildPaginationButtons, clampPage, splitIntoPages } from '../../discord/utils/index.js';
+import { formatBerry } from '../economy/utils/format-berry.js';
 
 import { INVENTORY_BUTTON_NAME } from './constants.js';
 import type { Inventory } from './types.js';
@@ -10,6 +11,7 @@ const EMPTY_INVENTORY_DESCRIPTION = 'Inventaire vide';
 
 export function buildInventoryView(player: Player, inventory: Inventory, page: number, ownerDiscordId: string): View {
   const embed = buildOpEmbed().setTitle(`Inventaire de ${player.name}`);
+  embed.addFields({ name: '💰 Berries', value: formatBerry(player.berries), inline: true });
   const menuRow = buildMenuButtons(INVENTORY_BUTTON_NAME, ownerDiscordId, player.id);
 
   if (inventory.length === 0) {

--- a/apps/bot/src/domains/ship/views/build-ship-view.ts
+++ b/apps/bot/src/domains/ship/views/build-ship-view.ts
@@ -41,7 +41,7 @@ function buildLocationFields(player: Player): Array<APIEmbedField> {
     positionField,
     {
       name: '🚢 Destination',
-      value: `${ZONE_LABELS[player.travelTargetZone]}(~${buildDiscordTimestamp(arrivalAt)})`,
+      value: `${ZONE_LABELS[player.travelTargetZone]}(Arrivée prévue dans ~${buildDiscordTimestamp(arrivalAt)})`,
       inline: true,
     },
   ];

--- a/apps/bot/src/domains/ship/views/build-ship-view.ts
+++ b/apps/bot/src/domains/ship/views/build-ship-view.ts
@@ -1,8 +1,9 @@
-import { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type Player } from '@one-piece/db';
-import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js';
+import { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, ZONE_LABELS, type Player } from '@one-piece/db';
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, type APIEmbedField } from 'discord.js';
 
 import type { View } from '../../../discord/types.js';
-import { buildCustomId, buildMenuButtons, buildOpEmbed } from '../../../discord/utils/index.js';
+import { buildCustomId, buildDiscordTimestamp, buildMenuButtons, buildOpEmbed } from '../../../discord/utils/index.js';
+import { getStartDateOfBucket } from '../../event/engine/bucket.js';
 import { SHIP_BUTTON_NAME, UPGRADE_MODULE_EMOJI, UPGRADE_SHIP_BUTTON_NAME } from '../constants.js';
 import { SHIP_MODULE_LABELS, SHIP_MODULES } from '../modules.js';
 import { findByPlayerIdOrThrow } from '../repository.js';
@@ -11,6 +12,7 @@ export async function buildShipView(player: Player, ownerDiscordId: string): Pro
   const ship = await findByPlayerIdOrThrow(player.id);
 
   const embed = buildOpEmbed().setTitle(`🚢 ${ship.name}`).setDescription(`HP : ${ship.hp}`);
+  embed.addFields(...buildLocationFields(player));
   // TODO: Redesign this shit
   for (const key of SHIP_MODULE_KEYS) {
     const level = ship[SHIP_MODULE_LEVEL_COLUMNS[key]];
@@ -27,6 +29,22 @@ export async function buildShipView(player: Player, ownerDiscordId: string): Pro
   const upgradeRow = isOwner ? buildUpgradeShipButtonRow(player.id, ownerDiscordId) : null;
 
   return { embeds: [embed], components: upgradeRow ? [upgradeRow, navRow] : [navRow] };
+}
+
+function buildLocationFields(player: Player): Array<APIEmbedField> {
+  const positionField: APIEmbedField = { name: '📍 Position', value: ZONE_LABELS[player.currentZone], inline: true };
+  if (player.travelTargetZone === null || player.travelEtaBucket === null) {
+    return [positionField];
+  }
+  const arrivalAt = getStartDateOfBucket(player.travelEtaBucket);
+  return [
+    positionField,
+    {
+      name: '🚢 Destination',
+      value: `${ZONE_LABELS[player.travelTargetZone]}(~${buildDiscordTimestamp(arrivalAt)})`,
+      inline: true,
+    },
+  ];
 }
 
 function buildUpgradeShipButtonRow(playerId: number, ownerDiscordId: string): ActionRowBuilder<ButtonBuilder> {

--- a/docs/domains/event/recap-flow.md
+++ b/docs/domains/event/recap-flow.md
@@ -33,7 +33,7 @@ Le routeur Discord (`apps/bot/src/discord/router.ts`) appelle `synchronizePlayer
 Selon le `SyncResult` :
 
 - `already_caught_up` → on enchaîne sur le handler, rien à dire.
-- `caught_up` avec `generatedPassiveCount > 0` → on envoie un message séparé `📜 Ton équipage a vécu N événement(s). Tape !recap pour les revivre.` **avant** d'enchaîner sur le handler. Les passives ont déjà été appliqués pendant la sync — pas besoin de bloquer.
+- `caught_up` avec `generatedPassiveCount > 0` → on envoie un message séparé `📜 Votre équipage a vécu N événement(s). Tapez !recap pour les revivre.` **avant** d'enchaîner sur le handler. Les passives ont déjà été appliqués pendant la sync — pas besoin de bloquer.
 - `blocked_on_interactive` → on `throw new OutOfSyncError(message.author.id)`. Le `catch` du routeur rend l'`userView` portée par l'erreur (cf #188) : un embed warn + un bouton "Voir mes events" (`recap-shortcut`) qui ramène vers `!recap`.
 
 > **Pourquoi un message séparé pour le footer plutôt qu'un append à la réponse de la commande** : éviter de coupler chaque handler (pêche, recrutement, etc.) à une logique de footer. UX-wise, deux messages restent fluides, et l'ordre temporel est naturel (footer avant la réponse de l'action).
@@ -79,9 +79,9 @@ Deux phases distinctes : **calcul** (rejouer les buckets, appliquer les effets, 
 
 Lecture de la queue (ordonnée par `bucket_id`) et affichage du **premier** event :
 
-- **Queue vide** → "Vous n'avez aucun événement en attente."
+- **Queue vide** → deux variantes selon le contexte : "Aucun évènement à consulter pour l'instant." (entrée fraîche dans `!recap`) ou "Plus d'évènements à consulter !" (fin de file après avoir déroulé). `buildRecapView(player, isContinuation)` porte le booléen.
 - **Passive en tête** → retrouver le générateur via `event_key`, appeler `render(state)`, afficher l'embed + bouton **Suivant**. Clic → DELETE l'`event_instance`, render le suivant.
-- **Interactive en tête** → appeler `steps[state.step].embed(state, ctx)` + boutons des choix. Clic sur un choix → appliquer les effets, DELETE `event_instance`, INSERT `history`, render le suivant (ou bien `goTo` une autre étape sans DELETE).
+- **Interactive en tête** → appeler `steps[state.step].embed(state, ctx)` + boutons des choix. Clic sur un choix → appliquer les effets, DELETE `event_instance`, INSERT `history`, **relancer `synchronizePlayer`** (le moteur s'était arrêté sur cet interactif, il faut rejouer les buckets suivants), puis afficher la **résolution seule + bouton Suivant**. Le clic Suivant reprend l'affichage en haut de queue. (Ou bien `goTo` une autre étape sans DELETE.)
 
 Le joueur peut interrompre à tout moment : la queue persiste. Au prochain `!recap`, on recalcule les nouveaux buckets (s'il y en a) puis on reprend l'affichage en haut de queue. Pas de cooldown sur `!recap`.
 


### PR DESCRIPTION
## Résumé
- Ajoute l'event interactif `cheatTeleport` (probabilité 0, déclenchable via `!force-event`) pour choisir une destination accessible depuis sa position.
- Refonte du flow `!recap` : après résolution d'un interactif, on affiche la résolution seule avec un bouton **Suivant**, et on relance `synchronizePlayer` pour que la suite de la timeline soit disponible au clic. Différencie aussi la vue vide « rien à consulter » vs « plus rien après ton recap ».
- Déplace les infos de navigation (Position + Destination avec timestamp d'arrivée) du `!profil` vers `!ship`, retire le nom d'équipage redondant du profil, et ajoute les berries dans `!inventaire`.
- Harmonise la narration des events au passé composé + « Vous » (cohérent avec le framing "tu te connectes, tu vois ce que tu as manqué").
- Branche enfin le flag admin au niveau du routeur : rename `requiresAdmin` → `requiresOpAdmin`, nouveau guard `assertPlayerIsAdmin` basé sur `player.isAdmin` du schéma. Au passage, supprime `isPlayerUpToDate` (dead code).
