### PR TITLE
logique de reserve

### DIFF
--- a/apps/bot/src/domains/crew/guards/assert-character-exists-and-belongs-to-player.ts
+++ b/apps/bot/src/domains/crew/guards/assert-character-exists-and-belongs-to-player.ts
@@ -1,0 +1,12 @@
+import type { CharacterInstance } from '@one-piece/db';
+
+import { ValidationError } from '../../../discord/errors.js';
+
+export function assertCharacterExistsAndBelongsToPlayer(
+  character: CharacterInstance | undefined,
+  playerId: number,
+): asserts character is CharacterInstance {
+  if (character?.playerId !== playerId) {
+    throw new ValidationError("Ce personnage ne t'appartient pas.");
+  }
+}

--- a/apps/bot/src/domains/crew/guards/assert-character-is-in-crew.ts
+++ b/apps/bot/src/domains/crew/guards/assert-character-is-in-crew.ts
@@ -1,0 +1,7 @@
+import { ValidationError } from '../../../discord/errors.js';
+
+export function assertCharacterIsInCrew(character: { joinedCrewAt: Date | null }): void {
+  if (character.joinedCrewAt === null) {
+    throw new ValidationError("Ce personnage n'est pas dans ton équipage.");
+  }
+}

--- a/apps/bot/src/domains/crew/guards/assert-character-is-not-already-in-crew.ts
+++ b/apps/bot/src/domains/crew/guards/assert-character-is-not-already-in-crew.ts
@@ -1,0 +1,7 @@
+import { ValidationError } from '../../../discord/errors.js';
+
+export function assertCharacterIsNotAlreadyInCrew(character: { joinedCrewAt: Date | null }): void {
+  if (character.joinedCrewAt !== null) {
+    throw new ValidationError('Ce personnage est déjà dans ton équipage.');
+  }
+}

--- a/apps/bot/src/domains/crew/guards/assert-character-is-not-captain.ts
+++ b/apps/bot/src/domains/crew/guards/assert-character-is-not-captain.ts
@@ -1,0 +1,7 @@
+import { ValidationError } from '../../../discord/errors.js';
+
+export function assertCharacterIsNotCaptain(character: { isCaptain: boolean }): void {
+  if (character.isCaptain) {
+    throw new ValidationError("Réassigne le capitaine d'abord avant de débarquer ce personnage.");
+  }
+}

--- a/apps/bot/src/domains/crew/guards/assert-crew-has-available-slot.ts
+++ b/apps/bot/src/domains/crew/guards/assert-crew-has-available-slot.ts
@@ -1,15 +1,13 @@
 import type { DbOrTransaction } from '@one-piece/db';
 
 import { ValidationError } from '../../../discord/errors.js';
-import * as characterRepository from '../../character/repository.js';
 import * as shipRepository from '../../ship/repository.js';
+import { getCrewByPlayerId } from '../service.js';
 import { getCrewCapacity } from '../utils/get-crew-capacity.js';
-import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
 
 export async function assertCrewHasAvailableSlot(playerId: number, client: DbOrTransaction): Promise<void> {
   const ship = await shipRepository.findByPlayerIdOrThrow(playerId, client, { forUpdate: true });
-  const characters = await characterRepository.getCharactersByPlayerId(playerId, client);
-  const crewSize = characters.filter(isInCrewFilter).length;
+  const crewSize = (await getCrewByPlayerId(playerId, client)).length;
 
   if (crewSize >= getCrewCapacity(ship)) {
     throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");

--- a/apps/bot/src/domains/crew/guards/assert-crew-has-available-slot.ts
+++ b/apps/bot/src/domains/crew/guards/assert-crew-has-available-slot.ts
@@ -1,0 +1,17 @@
+import type { DbOrTransaction } from '@one-piece/db';
+
+import { ValidationError } from '../../../discord/errors.js';
+import * as characterRepository from '../../character/repository.js';
+import * as shipRepository from '../../ship/repository.js';
+import { getCrewCapacity } from '../utils/get-crew-capacity.js';
+import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
+
+export async function assertCrewHasAvailableSlot(playerId: number, client: DbOrTransaction): Promise<void> {
+  const ship = await shipRepository.findByPlayerIdOrThrow(playerId, client, { forUpdate: true });
+  const characters = await characterRepository.getCharactersByPlayerId(playerId, client);
+  const crewSize = characters.filter(isInCrewFilter).length;
+
+  if (crewSize >= getCrewCapacity(ship)) {
+    throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");
+  }
+}

--- a/apps/bot/src/domains/crew/guards/index.ts
+++ b/apps/bot/src/domains/crew/guards/index.ts
@@ -1,0 +1,4 @@
+export { assertCharacterExistsAndBelongsToPlayer } from './assert-character-exists-and-belongs-to-player.js';
+export { assertCharacterIsInCrew } from './assert-character-is-in-crew.js';
+export { assertCharacterIsNotAlreadyInCrew } from './assert-character-is-not-already-in-crew.js';
+export { assertCharacterIsNotCaptain } from './assert-character-is-not-captain.js';

--- a/apps/bot/src/domains/crew/guards/index.ts
+++ b/apps/bot/src/domains/crew/guards/index.ts
@@ -2,3 +2,4 @@ export { assertCharacterExistsAndBelongsToPlayer } from './assert-character-exis
 export { assertCharacterIsInCrew } from './assert-character-is-in-crew.js';
 export { assertCharacterIsNotAlreadyInCrew } from './assert-character-is-not-already-in-crew.js';
 export { assertCharacterIsNotCaptain } from './assert-character-is-not-captain.js';
+export { assertCrewHasAvailableSlot } from './assert-crew-has-available-slot.js';

--- a/apps/bot/src/domains/crew/index.ts
+++ b/apps/bot/src/domains/crew/index.ts
@@ -1,2 +1,3 @@
 export { crewCommands } from './commands/index.js';
 export { crewButtonHandlers } from './interactions/index.js';
+export * from './guards/index.js';

--- a/apps/bot/src/domains/crew/repository.ts
+++ b/apps/bot/src/domains/crew/repository.ts
@@ -3,8 +3,21 @@ import { and, eq, isNotNull } from 'drizzle-orm';
 
 import { InternalError } from '../../discord/errors.js';
 
-export async function findCharacterInstanceById(instanceId: number): Promise<CharacterInstance | undefined> {
-  const [row] = await db.select().from(characterInstance).where(eq(characterInstance.id, instanceId)).limit(1);
+type FindCharacterInstanceByIdOptions = {
+  forUpdate?: boolean;
+};
+
+export async function findCharacterInstanceById(
+  instanceId: number,
+  client: DbOrTransaction = db,
+  options: FindCharacterInstanceByIdOptions = {},
+): Promise<CharacterInstance | undefined> {
+  if (options.forUpdate) {
+    const [row] = await client.select().from(characterInstance).where(eq(characterInstance.id, instanceId)).limit(1).for('update');
+    return row;
+  }
+
+  const [row] = await client.select().from(characterInstance).where(eq(characterInstance.id, instanceId)).limit(1);
   return row;
 }
 
@@ -26,4 +39,8 @@ export async function setCaptain(playerId: number, instanceId: number, client: D
     .where(and(eq(characterInstance.id, instanceId), eq(characterInstance.playerId, playerId), isNotNull(characterInstance.joinedCrewAt)));
 
   return result.count > 0;
+}
+
+export async function setCharacterCrewMembership(instanceId: number, joinedAt: Date | null, client: DbOrTransaction = db): Promise<void> {
+  await client.update(characterInstance).set({ joinedCrewAt: joinedAt }).where(eq(characterInstance.id, instanceId));
 }

--- a/apps/bot/src/domains/crew/repository.ts
+++ b/apps/bot/src/domains/crew/repository.ts
@@ -41,6 +41,6 @@ export async function setCaptain(playerId: number, instanceId: number, client: D
   return result.count > 0;
 }
 
-export async function setCharacterCrewMembership(instanceId: number, joinedAt: Date | null, client: DbOrTransaction = db): Promise<void> {
+export async function setCharacterJoinedAt(instanceId: number, joinedAt: Date | null, client: DbOrTransaction = db): Promise<void> {
   await client.update(characterInstance).set({ joinedCrewAt: joinedAt }).where(eq(characterInstance.id, instanceId));
 }

--- a/apps/bot/src/domains/crew/repository.ts
+++ b/apps/bot/src/domains/crew/repository.ts
@@ -12,12 +12,8 @@ export async function findCharacterInstanceById(
   client: DbOrTransaction = db,
   options: FindCharacterInstanceByIdOptions = {},
 ): Promise<CharacterInstance | undefined> {
-  if (options.forUpdate) {
-    const [row] = await client.select().from(characterInstance).where(eq(characterInstance.id, instanceId)).limit(1).for('update');
-    return row;
-  }
-
-  const [row] = await client.select().from(characterInstance).where(eq(characterInstance.id, instanceId)).limit(1);
+  const query = client.select().from(characterInstance).where(eq(characterInstance.id, instanceId)).limit(1);
+  const [row] = await (options.forUpdate ? query.for('update') : query);
   return row;
 }
 

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -1,4 +1,4 @@
-import { db, type CharacterInstance, type Player } from '@one-piece/db';
+import { db, type Player } from '@one-piece/db';
 
 import { NotFoundError, ValidationError } from '../../discord/errors.js';
 import { sanitizeName } from '../../shared/sanitize-name.js';
@@ -6,12 +6,12 @@ import * as characterRepository from '../character/repository.js';
 import type { CharacterRow } from '../character/types.js';
 import * as historyRepository from '../history/index.js';
 import * as playerRepository from '../player/repository.js';
-import * as shipRepository from '../ship/repository.js';
 
 import { MAX_CREW_NAME_LENGTH, MIN_CREW_NAME_LENGTH } from './constants.js';
 import * as crewRepository from './repository.js';
-import { getCrewCapacity } from './utils/get-crew-capacity.js';
 import { isInCrewFilter } from './utils/is-in-crew-filter.js';
+
+export { disembarkCharacter, embarkCharacter } from './services/crew-membership.js';
 
 export async function getCrewByPlayerId(playerId: number): Promise<Array<CharacterRow>> {
   const characters = await characterRepository.getCharactersByPlayerId(playerId);
@@ -22,34 +22,6 @@ export async function getCrewByPlayerId(playerId: number): Promise<Array<Charact
   }
 
   return crew;
-}
-
-export async function embarkCharacter(playerId: number, instanceId: number): Promise<void> {
-  await db.transaction(async (transaction) => {
-    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
-    assertCharacterBelongsToPlayer(character, playerId);
-    assertCharacterIsInReserve(character);
-
-    const ship = await shipRepository.findByPlayerIdOrThrow(playerId, transaction, { forUpdate: true });
-    const characters = await characterRepository.getCharactersByPlayerId(playerId, transaction);
-    const crewSize = characters.filter(isInCrewFilter).length;
-    if (crewSize >= getCrewCapacity(ship)) {
-      throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");
-    }
-
-    await crewRepository.setCharacterCrewMembership(instanceId, new Date(), transaction);
-  });
-}
-
-export async function disembarkCharacter(playerId: number, instanceId: number): Promise<void> {
-  await db.transaction(async (transaction) => {
-    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
-    assertCharacterBelongsToPlayer(character, playerId);
-    assertCharacterIsInCrew(character);
-    assertCharacterIsNotCaptain(character);
-
-    await crewRepository.setCharacterCrewMembership(instanceId, null, transaction);
-  });
 }
 
 export async function replaceCaptainOfPlayer(playerId: number, instanceId: number): Promise<void> {
@@ -87,31 +59,4 @@ export async function renameCrew(playerId: number, rawName: string): Promise<Pla
   }
 
   return playerRepository.updateCrewName(playerId, sanitizedName);
-}
-
-function assertCharacterBelongsToPlayer(
-  character: CharacterInstance | undefined,
-  playerId: number,
-): asserts character is CharacterInstance {
-  if (character?.playerId === playerId) return;
-
-  throw new ValidationError("Ce personnage ne t'appartient pas.");
-}
-
-function assertCharacterIsInReserve(character: { joinedCrewAt: Date | null }): void {
-  if (character.joinedCrewAt === null) return;
-
-  throw new ValidationError('Ce personnage est déjà dans ton équipage.');
-}
-
-function assertCharacterIsInCrew(character: { joinedCrewAt: Date | null }): void {
-  if (character.joinedCrewAt !== null) return;
-
-  throw new ValidationError("Ce personnage n'est pas dans ton équipage.");
-}
-
-function assertCharacterIsNotCaptain(character: { isCaptain: boolean }): void {
-  if (!character.isCaptain) return;
-
-  throw new ValidationError("Réassigne le capitaine d'abord avec !changecaptain.");
 }

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -1,4 +1,4 @@
-import { db, type Player } from '@one-piece/db';
+import { db, type DbOrTransaction, type Player } from '@one-piece/db';
 
 import { NotFoundError, ValidationError } from '../../discord/errors.js';
 import { sanitizeName } from '../../shared/sanitize-name.js';
@@ -11,8 +11,8 @@ import { MAX_CREW_NAME_LENGTH, MIN_CREW_NAME_LENGTH } from './constants.js';
 import * as crewRepository from './repository.js';
 import { isInCrewFilter } from './utils/is-in-crew-filter.js';
 
-export async function getCrewByPlayerId(playerId: number): Promise<Array<CharacterRow>> {
-  const characters = await characterRepository.getCharactersByPlayerId(playerId);
+export async function getCrewByPlayerId(playerId: number, client: DbOrTransaction = db): Promise<Array<CharacterRow>> {
+  const characters = await characterRepository.getCharactersByPlayerId(playerId, client);
   const crew = characters.filter(isInCrewFilter);
 
   if (crew.length === 0) {

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -1,4 +1,4 @@
-import { db, type Player } from '@one-piece/db';
+import { db, type CharacterInstance, type Player } from '@one-piece/db';
 
 import { NotFoundError, ValidationError } from '../../discord/errors.js';
 import { sanitizeName } from '../../shared/sanitize-name.js';
@@ -6,9 +6,11 @@ import * as characterRepository from '../character/repository.js';
 import type { CharacterRow } from '../character/types.js';
 import * as historyRepository from '../history/index.js';
 import * as playerRepository from '../player/repository.js';
+import * as shipRepository from '../ship/repository.js';
 
 import { MAX_CREW_NAME_LENGTH, MIN_CREW_NAME_LENGTH } from './constants.js';
 import * as crewRepository from './repository.js';
+import { getCrewCapacity } from './utils/get-crew-capacity.js';
 import { isInCrewFilter } from './utils/is-in-crew-filter.js';
 
 export async function getCrewByPlayerId(playerId: number): Promise<Array<CharacterRow>> {
@@ -20,6 +22,34 @@ export async function getCrewByPlayerId(playerId: number): Promise<Array<Charact
   }
 
   return crew;
+}
+
+export async function embarkCharacter(playerId: number, instanceId: number): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
+    assertCharacterBelongsToPlayer(character, playerId);
+    assertCharacterIsInReserve(character);
+
+    const ship = await shipRepository.findByPlayerIdOrThrow(playerId, transaction, { forUpdate: true });
+    const characters = await characterRepository.getCharactersByPlayerId(playerId, transaction);
+    const crewSize = characters.filter(isInCrewFilter).length;
+    if (crewSize >= getCrewCapacity(ship)) {
+      throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");
+    }
+
+    await crewRepository.setCharacterCrewMembership(instanceId, new Date(), transaction);
+  });
+}
+
+export async function disembarkCharacter(playerId: number, instanceId: number): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
+    assertCharacterBelongsToPlayer(character, playerId);
+    assertCharacterIsInCrew(character);
+    assertCharacterIsNotCaptain(character);
+
+    await crewRepository.setCharacterCrewMembership(instanceId, null, transaction);
+  });
 }
 
 export async function replaceCaptainOfPlayer(playerId: number, instanceId: number): Promise<void> {
@@ -57,4 +87,31 @@ export async function renameCrew(playerId: number, rawName: string): Promise<Pla
   }
 
   return playerRepository.updateCrewName(playerId, sanitizedName);
+}
+
+function assertCharacterBelongsToPlayer(
+  character: CharacterInstance | undefined,
+  playerId: number,
+): asserts character is CharacterInstance {
+  if (character?.playerId === playerId) return;
+
+  throw new ValidationError("Ce personnage ne t'appartient pas.");
+}
+
+function assertCharacterIsInReserve(character: { joinedCrewAt: Date | null }): void {
+  if (character.joinedCrewAt === null) return;
+
+  throw new ValidationError('Ce personnage est déjà dans ton équipage.');
+}
+
+function assertCharacterIsInCrew(character: { joinedCrewAt: Date | null }): void {
+  if (character.joinedCrewAt !== null) return;
+
+  throw new ValidationError("Ce personnage n'est pas dans ton équipage.");
+}
+
+function assertCharacterIsNotCaptain(character: { isCaptain: boolean }): void {
+  if (!character.isCaptain) return;
+
+  throw new ValidationError("Réassigne le capitaine d'abord avec !changecaptain.");
 }

--- a/apps/bot/src/domains/crew/service.ts
+++ b/apps/bot/src/domains/crew/service.ts
@@ -11,8 +11,6 @@ import { MAX_CREW_NAME_LENGTH, MIN_CREW_NAME_LENGTH } from './constants.js';
 import * as crewRepository from './repository.js';
 import { isInCrewFilter } from './utils/is-in-crew-filter.js';
 
-export { disembarkCharacter, embarkCharacter } from './services/crew-membership.js';
-
 export async function getCrewByPlayerId(playerId: number): Promise<Array<CharacterRow>> {
   const characters = await characterRepository.getCharactersByPlayerId(playerId);
   const crew = characters.filter(isInCrewFilter);

--- a/apps/bot/src/domains/crew/services/crew-membership.ts
+++ b/apps/bot/src/domains/crew/services/crew-membership.ts
@@ -1,0 +1,63 @@
+import { db, type CharacterInstance } from '@one-piece/db';
+
+import { ValidationError } from '../../../discord/errors.js';
+import * as characterRepository from '../../character/repository.js';
+import * as shipRepository from '../../ship/repository.js';
+import * as crewRepository from '../repository.js';
+import { getCrewCapacity } from '../utils/get-crew-capacity.js';
+import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
+
+export async function embarkCharacter(playerId: number, instanceId: number): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
+    assertCharacterBelongsToPlayer(character, playerId);
+    assertCharacterIsInReserve(character);
+
+    const ship = await shipRepository.findByPlayerIdOrThrow(playerId, transaction, { forUpdate: true });
+    const characters = await characterRepository.getCharactersByPlayerId(playerId, transaction);
+    const crewSize = characters.filter(isInCrewFilter).length;
+    if (crewSize >= getCrewCapacity(ship)) {
+      throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");
+    }
+
+    await crewRepository.setCharacterJoinedAt(instanceId, new Date(), transaction);
+  });
+}
+
+export async function disembarkCharacter(playerId: number, instanceId: number): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
+    assertCharacterBelongsToPlayer(character, playerId);
+    assertCharacterIsInCrew(character);
+    assertCharacterIsNotCaptain(character);
+
+    await crewRepository.setCharacterJoinedAt(instanceId, null, transaction);
+  });
+}
+
+function assertCharacterBelongsToPlayer(
+  character: CharacterInstance | undefined,
+  playerId: number,
+): asserts character is CharacterInstance {
+  if (character?.playerId !== playerId) {
+    throw new ValidationError("Ce personnage ne t'appartient pas.");
+  }
+}
+
+function assertCharacterIsInReserve(character: { joinedCrewAt: Date | null }): void {
+  if (character.joinedCrewAt !== null) {
+    throw new ValidationError('Ce personnage est déjà dans ton équipage.');
+  }
+}
+
+function assertCharacterIsInCrew(character: { joinedCrewAt: Date | null }): void {
+  if (character.joinedCrewAt === null) {
+    throw new ValidationError("Ce personnage n'est pas dans ton équipage.");
+  }
+}
+
+function assertCharacterIsNotCaptain(character: { isCaptain: boolean }): void {
+  if (character.isCaptain) {
+    throw new ValidationError("Réassigne le capitaine d'abord avec !changecaptain.");
+  }
+}

--- a/apps/bot/src/domains/crew/services/disembark-character.ts
+++ b/apps/bot/src/domains/crew/services/disembark-character.ts
@@ -1,36 +1,15 @@
-import { db, type CharacterInstance } from '@one-piece/db';
+import { db } from '@one-piece/db';
 
-import { ValidationError } from '../../../discord/errors.js';
+import { assertCharacterExistsAndBelongsToPlayer, assertCharacterIsInCrew, assertCharacterIsNotCaptain } from '../guards/index.js';
 import * as crewRepository from '../repository.js';
 
 export async function disembarkCharacter(playerId: number, instanceId: number): Promise<void> {
   await db.transaction(async (transaction) => {
     const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
-    assertCharacterBelongsToPlayer(character, playerId);
+    assertCharacterExistsAndBelongsToPlayer(character, playerId);
     assertCharacterIsInCrew(character);
     assertCharacterIsNotCaptain(character);
 
     await crewRepository.setCharacterJoinedAt(instanceId, null, transaction);
   });
-}
-
-function assertCharacterBelongsToPlayer(
-  character: CharacterInstance | undefined,
-  playerId: number,
-): asserts character is CharacterInstance {
-  if (character?.playerId !== playerId) {
-    throw new ValidationError("Ce personnage ne t'appartient pas.");
-  }
-}
-
-function assertCharacterIsInCrew(character: { joinedCrewAt: Date | null }): void {
-  if (character.joinedCrewAt === null) {
-    throw new ValidationError("Ce personnage n'est pas dans ton équipage.");
-  }
-}
-
-function assertCharacterIsNotCaptain(character: { isCaptain: boolean }): void {
-  if (character.isCaptain) {
-    throw new ValidationError("Réassigne le capitaine d'abord avec !changecaptain.");
-  }
 }

--- a/apps/bot/src/domains/crew/services/disembark-character.ts
+++ b/apps/bot/src/domains/crew/services/disembark-character.ts
@@ -1,28 +1,7 @@
 import { db, type CharacterInstance } from '@one-piece/db';
 
 import { ValidationError } from '../../../discord/errors.js';
-import * as characterRepository from '../../character/repository.js';
-import * as shipRepository from '../../ship/repository.js';
 import * as crewRepository from '../repository.js';
-import { getCrewCapacity } from '../utils/get-crew-capacity.js';
-import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
-
-export async function embarkCharacter(playerId: number, instanceId: number): Promise<void> {
-  await db.transaction(async (transaction) => {
-    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
-    assertCharacterBelongsToPlayer(character, playerId);
-    assertCharacterIsInReserve(character);
-
-    const ship = await shipRepository.findByPlayerIdOrThrow(playerId, transaction, { forUpdate: true });
-    const characters = await characterRepository.getCharactersByPlayerId(playerId, transaction);
-    const crewSize = characters.filter(isInCrewFilter).length;
-    if (crewSize >= getCrewCapacity(ship)) {
-      throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");
-    }
-
-    await crewRepository.setCharacterJoinedAt(instanceId, new Date(), transaction);
-  });
-}
 
 export async function disembarkCharacter(playerId: number, instanceId: number): Promise<void> {
   await db.transaction(async (transaction) => {
@@ -41,12 +20,6 @@ function assertCharacterBelongsToPlayer(
 ): asserts character is CharacterInstance {
   if (character?.playerId !== playerId) {
     throw new ValidationError("Ce personnage ne t'appartient pas.");
-  }
-}
-
-function assertCharacterIsInReserve(character: { joinedCrewAt: Date | null }): void {
-  if (character.joinedCrewAt !== null) {
-    throw new ValidationError('Ce personnage est déjà dans ton équipage.');
   }
 }
 

--- a/apps/bot/src/domains/crew/services/embark-character.ts
+++ b/apps/bot/src/domains/crew/services/embark-character.ts
@@ -1,0 +1,40 @@
+import { db, type CharacterInstance } from '@one-piece/db';
+
+import { ValidationError } from '../../../discord/errors.js';
+import * as characterRepository from '../../character/repository.js';
+import * as shipRepository from '../../ship/repository.js';
+import * as crewRepository from '../repository.js';
+import { getCrewCapacity } from '../utils/get-crew-capacity.js';
+import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
+
+export async function embarkCharacter(playerId: number, instanceId: number): Promise<void> {
+  await db.transaction(async (transaction) => {
+    const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
+    assertCharacterBelongsToPlayer(character, playerId);
+    assertCharacterIsInReserve(character);
+
+    const ship = await shipRepository.findByPlayerIdOrThrow(playerId, transaction, { forUpdate: true });
+    const characters = await characterRepository.getCharactersByPlayerId(playerId, transaction);
+    const crewSize = characters.filter(isInCrewFilter).length;
+    if (crewSize >= getCrewCapacity(ship)) {
+      throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");
+    }
+
+    await crewRepository.setCharacterJoinedAt(instanceId, new Date(), transaction);
+  });
+}
+
+function assertCharacterBelongsToPlayer(
+  character: CharacterInstance | undefined,
+  playerId: number,
+): asserts character is CharacterInstance {
+  if (character?.playerId !== playerId) {
+    throw new ValidationError("Ce personnage ne t'appartient pas.");
+  }
+}
+
+function assertCharacterIsInReserve(character: { joinedCrewAt: Date | null }): void {
+  if (character.joinedCrewAt !== null) {
+    throw new ValidationError('Ce personnage est déjà dans ton équipage.');
+  }
+}

--- a/apps/bot/src/domains/crew/services/embark-character.ts
+++ b/apps/bot/src/domains/crew/services/embark-character.ts
@@ -1,25 +1,14 @@
 import { db } from '@one-piece/db';
 
-import { ValidationError } from '../../../discord/errors.js';
-import * as characterRepository from '../../character/repository.js';
-import * as shipRepository from '../../ship/repository.js';
-import { assertCharacterExistsAndBelongsToPlayer, assertCharacterIsNotAlreadyInCrew } from '../guards/index.js';
+import { assertCharacterExistsAndBelongsToPlayer, assertCharacterIsNotAlreadyInCrew, assertCrewHasAvailableSlot } from '../guards/index.js';
 import * as crewRepository from '../repository.js';
-import { getCrewCapacity } from '../utils/get-crew-capacity.js';
-import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
 
 export async function embarkCharacter(playerId: number, instanceId: number): Promise<void> {
   await db.transaction(async (transaction) => {
     const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
     assertCharacterExistsAndBelongsToPlayer(character, playerId);
     assertCharacterIsNotAlreadyInCrew(character);
-
-    const ship = await shipRepository.findByPlayerIdOrThrow(playerId, transaction, { forUpdate: true });
-    const characters = await characterRepository.getCharactersByPlayerId(playerId, transaction);
-    const crewSize = characters.filter(isInCrewFilter).length;
-    if (crewSize >= getCrewCapacity(ship)) {
-      throw new ValidationError("Ton équipage est plein, débarque quelqu'un d'abord.");
-    }
+    await assertCrewHasAvailableSlot(playerId, transaction);
 
     await crewRepository.setCharacterJoinedAt(instanceId, new Date(), transaction);
   });

--- a/apps/bot/src/domains/crew/services/embark-character.ts
+++ b/apps/bot/src/domains/crew/services/embark-character.ts
@@ -1,8 +1,9 @@
-import { db, type CharacterInstance } from '@one-piece/db';
+import { db } from '@one-piece/db';
 
 import { ValidationError } from '../../../discord/errors.js';
 import * as characterRepository from '../../character/repository.js';
 import * as shipRepository from '../../ship/repository.js';
+import { assertCharacterExistsAndBelongsToPlayer, assertCharacterIsNotAlreadyInCrew } from '../guards/index.js';
 import * as crewRepository from '../repository.js';
 import { getCrewCapacity } from '../utils/get-crew-capacity.js';
 import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
@@ -10,8 +11,8 @@ import { isInCrewFilter } from '../utils/is-in-crew-filter.js';
 export async function embarkCharacter(playerId: number, instanceId: number): Promise<void> {
   await db.transaction(async (transaction) => {
     const character = await crewRepository.findCharacterInstanceById(instanceId, transaction, { forUpdate: true });
-    assertCharacterBelongsToPlayer(character, playerId);
-    assertCharacterIsInReserve(character);
+    assertCharacterExistsAndBelongsToPlayer(character, playerId);
+    assertCharacterIsNotAlreadyInCrew(character);
 
     const ship = await shipRepository.findByPlayerIdOrThrow(playerId, transaction, { forUpdate: true });
     const characters = await characterRepository.getCharactersByPlayerId(playerId, transaction);
@@ -22,19 +23,4 @@ export async function embarkCharacter(playerId: number, instanceId: number): Pro
 
     await crewRepository.setCharacterJoinedAt(instanceId, new Date(), transaction);
   });
-}
-
-function assertCharacterBelongsToPlayer(
-  character: CharacterInstance | undefined,
-  playerId: number,
-): asserts character is CharacterInstance {
-  if (character?.playerId !== playerId) {
-    throw new ValidationError("Ce personnage ne t'appartient pas.");
-  }
-}
-
-function assertCharacterIsInReserve(character: { joinedCrewAt: Date | null }): void {
-  if (character.joinedCrewAt !== null) {
-    throw new ValidationError('Ce personnage est déjà dans ton équipage.');
-  }
 }

--- a/apps/bot/src/domains/crew/services/index.ts
+++ b/apps/bot/src/domains/crew/services/index.ts
@@ -1,0 +1,2 @@
+export { disembarkCharacter } from './disembark-character.js';
+export { embarkCharacter } from './embark-character.js';


### PR DESCRIPTION
## Résumé

Ajoute les fonctions métier de base pour déplacer un personnage entre la réserve et l’équipage.

## Changements

- Ajout de `embarkCharacter(playerId, instanceId)`
- Ajout de `disembarkCharacter(playerId, instanceId)`
- Ajout du helper repository `setCharacterCrewMembership(instanceId, joinedAt)`
- Validation de l’ownership, de l’état réserve/équipage, de la capacité du bateau et du blocage du capitaine