### PR TITLE
effectiv stats

### DIFF
--- a/apps/bot/src/domains/character/build-info-embed.ts
+++ b/apps/bot/src/domains/character/build-info-embed.ts
@@ -4,21 +4,21 @@ import { buildOpEmbed } from '../../discord/utils/index.js';
 import { buildAssetUrl } from '../../shared/build-asset-url.js';
 import { DOMAIN_EMOJI, DOMAIN_LABEL } from '../../shared/domains.js';
 
-import type { CharacterTemplateInfo } from './types.js';
+import type { CharacterTemplateWithDevilFruit } from './types.js';
 import { getEffectiveStats } from './utils/index.js';
 
 // TODO: design de l'embed character à revoir (emojis, couleur, mise en forme HP/Combat)
-export function buildCharacterInfoEmbed(template: CharacterTemplateInfo): EmbedBuilder {
+export function buildCharacterInfoEmbed(template: CharacterTemplateWithDevilFruit): EmbedBuilder {
   const stats = getEffectiveStats(template);
 
   const embed = buildOpEmbed()
     .setTitle(template.name)
     .setFooter({ text: `${DOMAIN_EMOJI.character} ${DOMAIN_LABEL.character}` })
     .addFields(
-      { name: 'HP', value: formatEffectiveStat(stats.hp, template.devilFruit?.hpBonus ?? 0), inline: true },
-      { name: 'Combat', value: formatEffectiveStat(stats.combat, template.devilFruit?.combatBonus ?? 0), inline: true },
-      { name: 'Fruit du Démon', value: template.devilFruitName ?? '—', inline: true },
-      { name: 'Types', value: formatTypes(template.devilFruitTypes), inline: true },
+      { name: 'HP', value: String(stats.hp), inline: true },
+      { name: 'Combat', value: String(stats.combat), inline: true },
+      { name: 'Fruit du Démon', value: template.devilFruit?.name ?? '—', inline: true },
+      { name: 'Types', value: formatTypes(template.devilFruit?.types ?? null), inline: true },
     );
 
   if (template.imageUrl) {
@@ -35,14 +35,4 @@ export function buildCharacterInfoEmbed(template: CharacterTemplateInfo): EmbedB
 function formatTypes(types: Array<string> | null): string {
   if (!types || types.length === 0) return '—';
   return types.join(', ');
-}
-
-function formatEffectiveStat(value: number, devilFruitBonus: number): string {
-  if (devilFruitBonus === 0) return String(value);
-
-  return `${value} (${formatSignedBonus(devilFruitBonus)} grâce au fruit)`;
-}
-
-function formatSignedBonus(value: number): string {
-  return value > 0 ? `+${value}` : String(value);
 }

--- a/apps/bot/src/domains/character/build-info-embed.ts
+++ b/apps/bot/src/domains/character/build-info-embed.ts
@@ -5,15 +5,18 @@ import { buildAssetUrl } from '../../shared/build-asset-url.js';
 import { DOMAIN_EMOJI, DOMAIN_LABEL } from '../../shared/domains.js';
 
 import type { CharacterTemplateInfo } from './types.js';
+import { getEffectiveStats } from './utils/index.js';
 
 // TODO: design de l'embed character à revoir (emojis, couleur, mise en forme HP/Combat)
 export function buildCharacterInfoEmbed(template: CharacterTemplateInfo): EmbedBuilder {
+  const stats = getEffectiveStats(template);
+
   const embed = buildOpEmbed()
     .setTitle(template.name)
     .setFooter({ text: `${DOMAIN_EMOJI.character} ${DOMAIN_LABEL.character}` })
     .addFields(
-      { name: 'HP', value: String(template.hp), inline: true },
-      { name: 'Combat', value: String(template.combat), inline: true },
+      { name: 'HP', value: formatEffectiveStat(stats.hp, template.devilFruit?.hpBonus ?? 0), inline: true },
+      { name: 'Combat', value: formatEffectiveStat(stats.combat, template.devilFruit?.combatBonus ?? 0), inline: true },
       { name: 'Fruit du Démon', value: template.devilFruitName ?? '—', inline: true },
       { name: 'Types', value: formatTypes(template.devilFruitTypes), inline: true },
     );
@@ -32,4 +35,14 @@ export function buildCharacterInfoEmbed(template: CharacterTemplateInfo): EmbedB
 function formatTypes(types: Array<string> | null): string {
   if (!types || types.length === 0) return '—';
   return types.join(', ');
+}
+
+function formatEffectiveStat(value: number, devilFruitBonus: number): string {
+  if (devilFruitBonus === 0) return String(value);
+
+  return `${value} (${formatSignedBonus(devilFruitBonus)} grâce au fruit)`;
+}
+
+function formatSignedBonus(value: number): string {
+  return value > 0 ? `+${value}` : String(value);
 }

--- a/apps/bot/src/domains/character/repository.ts
+++ b/apps/bot/src/domains/character/repository.ts
@@ -12,7 +12,7 @@ import { and, asc, desc, eq, getTableColumns, ilike, ne, or, sql } from 'drizzle
 
 import { InternalError, NotFoundError } from '../../discord/errors.js';
 
-import type { CharacterRow, CharacterTemplateInfo } from './types.js';
+import type { CharacterRow, CharacterTemplateWithDevilFruit } from './types.js';
 
 export async function getCharactersByPlayerId(playerId: number, client: DbOrTransaction = db): Promise<Array<CharacterRow>> {
   return client
@@ -23,10 +23,7 @@ export async function getCharactersByPlayerId(playerId: number, client: DbOrTran
       imageUrl: characterTemplate.imageUrl,
       hp: characterTemplate.hp,
       combat: characterTemplate.combat,
-      devilFruit: {
-        hpBonus: devilFruitTemplate.hpBonus,
-        combatBonus: devilFruitTemplate.combatBonus,
-      },
+      devilFruit: getTableColumns(devilFruitTemplate),
       joinedCrewAt: characterInstance.joinedCrewAt,
       isCaptain: characterInstance.isCaptain,
     })
@@ -62,10 +59,7 @@ export async function createCharacterInstance(playerId: number, templateId: numb
       imageUrl: characterTemplate.imageUrl,
       hp: characterTemplate.hp,
       combat: characterTemplate.combat,
-      devilFruit: {
-        hpBonus: devilFruitTemplate.hpBonus,
-        combatBonus: devilFruitTemplate.combatBonus,
-      },
+      devilFruit: getTableColumns(devilFruitTemplate),
       joinedCrewAt: characterInstance.joinedCrewAt,
       isCaptain: characterInstance.isCaptain,
     })
@@ -103,16 +97,11 @@ export async function searchManyByName(query: string): Promise<Array<{ entity: C
   return rows.map(({ score, ...entity }) => ({ entity, score }));
 }
 
-export async function findById(id: number): Promise<CharacterTemplateInfo | undefined> {
+export async function findById(id: number): Promise<CharacterTemplateWithDevilFruit | undefined> {
   const [row] = await db
     .select({
       ...getTableColumns(characterTemplate),
-      devilFruitName: devilFruitTemplate.name,
-      devilFruitTypes: devilFruitTemplate.types,
-      devilFruit: {
-        hpBonus: devilFruitTemplate.hpBonus,
-        combatBonus: devilFruitTemplate.combatBonus,
-      },
+      devilFruit: getTableColumns(devilFruitTemplate),
     })
     .from(characterTemplate)
     .leftJoin(devilFruitTemplate, eq(devilFruitTemplate.id, characterTemplate.devilFruitTemplateId))

--- a/apps/bot/src/domains/character/repository.ts
+++ b/apps/bot/src/domains/character/repository.ts
@@ -23,11 +23,22 @@ export async function getCharactersByPlayerId(playerId: number, client: DbOrTran
       imageUrl: characterTemplate.imageUrl,
       hp: characterTemplate.hp,
       combat: characterTemplate.combat,
+      devilFruit: {
+        hpBonus: devilFruitTemplate.hpBonus,
+        combatBonus: devilFruitTemplate.combatBonus,
+      },
       joinedCrewAt: characterInstance.joinedCrewAt,
       isCaptain: characterInstance.isCaptain,
     })
     .from(characterInstance)
     .innerJoin(characterTemplate, eq(characterInstance.templateId, characterTemplate.id))
+    .leftJoin(
+      devilFruitTemplate,
+      eq(
+        devilFruitTemplate.id,
+        sql<number>`coalesce(${characterTemplate.devilFruitTemplateId}, ${characterInstance.devilFruitTemplateId})`,
+      ),
+    )
     .where(eq(characterInstance.playerId, playerId))
     .orderBy(desc(characterInstance.isCaptain), sql`${characterInstance.joinedCrewAt} asc nulls last`, asc(characterTemplate.name));
 }
@@ -51,11 +62,22 @@ export async function createCharacterInstance(playerId: number, templateId: numb
       imageUrl: characterTemplate.imageUrl,
       hp: characterTemplate.hp,
       combat: characterTemplate.combat,
+      devilFruit: {
+        hpBonus: devilFruitTemplate.hpBonus,
+        combatBonus: devilFruitTemplate.combatBonus,
+      },
       joinedCrewAt: characterInstance.joinedCrewAt,
       isCaptain: characterInstance.isCaptain,
     })
     .from(characterInstance)
     .innerJoin(characterTemplate, eq(characterInstance.templateId, characterTemplate.id))
+    .leftJoin(
+      devilFruitTemplate,
+      eq(
+        devilFruitTemplate.id,
+        sql<number>`coalesce(${characterTemplate.devilFruitTemplateId}, ${characterInstance.devilFruitTemplateId})`,
+      ),
+    )
     .where(eq(characterInstance.id, created.id))
     .limit(1);
   if (!createdRow) throw new InternalError('Impossible de récupérer le personnage créé.');
@@ -87,6 +109,10 @@ export async function findById(id: number): Promise<CharacterTemplateInfo | unde
       ...getTableColumns(characterTemplate),
       devilFruitName: devilFruitTemplate.name,
       devilFruitTypes: devilFruitTemplate.types,
+      devilFruit: {
+        hpBonus: devilFruitTemplate.hpBonus,
+        combatBonus: devilFruitTemplate.combatBonus,
+      },
     })
     .from(characterTemplate)
     .leftJoin(devilFruitTemplate, eq(devilFruitTemplate.id, characterTemplate.devilFruitTemplateId))

--- a/apps/bot/src/domains/character/types.ts
+++ b/apps/bot/src/domains/character/types.ts
@@ -1,5 +1,7 @@
 import type { CharacterTemplate, DevilFruitTemplate } from '@one-piece/db';
 
+type DevilFruitStats = Pick<DevilFruitTemplate, 'combatBonus' | 'hpBonus'>;
+
 // TODO: RENOMMER EN Character tout court et ajouter le type devil fruit et PICK depuis les schémas db
 /** Row (character_instance + character_template) utilisée par les vues métier. */
 export type CharacterRow = {
@@ -9,6 +11,7 @@ export type CharacterRow = {
   imageUrl: string | null;
   hp: number;
   combat: number;
+  devilFruit: DevilFruitStats | null;
   joinedCrewAt: Date | null;
   isCaptain: boolean;
 };
@@ -16,4 +19,5 @@ export type CharacterRow = {
 export type CharacterTemplateInfo = CharacterTemplate & {
   devilFruitName: string | null;
   devilFruitTypes: DevilFruitTemplate['types'] | null;
+  devilFruit: DevilFruitStats | null;
 };

--- a/apps/bot/src/domains/character/types.ts
+++ b/apps/bot/src/domains/character/types.ts
@@ -1,7 +1,5 @@
 import type { CharacterTemplate, DevilFruitTemplate } from '@one-piece/db';
 
-type DevilFruitStats = Pick<DevilFruitTemplate, 'combatBonus' | 'hpBonus'>;
-
 // TODO: RENOMMER EN Character tout court et ajouter le type devil fruit et PICK depuis les schémas db
 /** Row (character_instance + character_template) utilisée par les vues métier. */
 export type CharacterRow = {
@@ -11,13 +9,11 @@ export type CharacterRow = {
   imageUrl: string | null;
   hp: number;
   combat: number;
-  devilFruit: DevilFruitStats | null;
+  devilFruit: DevilFruitTemplate | null;
   joinedCrewAt: Date | null;
   isCaptain: boolean;
 };
 
-export type CharacterTemplateInfo = CharacterTemplate & {
-  devilFruitName: string | null;
-  devilFruitTypes: DevilFruitTemplate['types'] | null;
-  devilFruit: DevilFruitStats | null;
+export type CharacterTemplateWithDevilFruit = CharacterTemplate & {
+  devilFruit: DevilFruitTemplate | null;
 };

--- a/apps/bot/src/domains/character/utils/get-effective-stats.ts
+++ b/apps/bot/src/domains/character/utils/get-effective-stats.ts
@@ -1,0 +1,10 @@
+import type { CharacterRow } from '../types.js';
+
+type CharacterStatsSource = Pick<CharacterRow, 'combat' | 'devilFruit' | 'hp'>;
+
+export function getEffectiveStats(character: CharacterStatsSource): { combat: number; hp: number } {
+  return {
+    combat: character.combat + (character.devilFruit?.combatBonus ?? 0),
+    hp: character.hp + (character.devilFruit?.hpBonus ?? 0),
+  };
+}

--- a/apps/bot/src/domains/character/utils/get-effective-stats.ts
+++ b/apps/bot/src/domains/character/utils/get-effective-stats.ts
@@ -1,8 +1,8 @@
-import type { CharacterRow } from '../types.js';
+import type { CharacterCombatStats } from '@one-piece/db';
 
-type CharacterStatsSource = Pick<CharacterRow, 'combat' | 'devilFruit' | 'hp'>;
+import type { CharacterRow, CharacterTemplateWithDevilFruit } from '../types.js';
 
-export function getEffectiveStats(character: CharacterStatsSource): { combat: number; hp: number } {
+export function getEffectiveStats(character: CharacterRow | CharacterTemplateWithDevilFruit): CharacterCombatStats {
   return {
     combat: character.combat + (character.devilFruit?.combatBonus ?? 0),
     hp: character.hp + (character.devilFruit?.hpBonus ?? 0),

--- a/apps/bot/src/domains/character/utils/index.ts
+++ b/apps/bot/src/domains/character/utils/index.ts
@@ -1,2 +1,3 @@
 export { getCharacterInstanceName } from './get-character-instance-name.js';
 export { getCharacterInstanceFruit } from './get-character-instance-fruit.js';
+export { getEffectiveStats } from './get-effective-stats.js';

--- a/apps/bot/src/domains/devil_fruit/build-info-embed.ts
+++ b/apps/bot/src/domains/devil_fruit/build-info-embed.ts
@@ -17,6 +17,9 @@ export function buildDevilFruitInfoEmbed(fruit: DevilFruitTemplate): EmbedBuilde
         value: fruit.types.length > 0 ? fruit.types.join(', ') : '—',
         inline: true,
       },
+      // TODO: Il faut styliser ça et ajouter des emojis
+      { name: 'HP', value: formatDfBonus(fruit.hpBonus), inline: true },
+      { name: 'Combat', value: formatDfBonus(fruit.combatBonus), inline: true },
     );
 
   if (fruit.imageUrl) {
@@ -24,4 +27,8 @@ export function buildDevilFruitInfoEmbed(fruit: DevilFruitTemplate): EmbedBuilde
   }
 
   return embed;
+}
+
+function formatDfBonus(value: number): string {
+  return value >= 0 ? `+${value}` : String(value);
 }

--- a/apps/bot/src/domains/devil_fruit/build-info-embed.ts
+++ b/apps/bot/src/domains/devil_fruit/build-info-embed.ts
@@ -17,9 +17,6 @@ export function buildDevilFruitInfoEmbed(fruit: DevilFruitTemplate): EmbedBuilde
         value: fruit.types.length > 0 ? fruit.types.join(', ') : '—',
         inline: true,
       },
-      // TODO: Il faut styliser ça et ajouter des emojis
-      { name: 'HP', value: formatDfBonus(fruit.hpBonus), inline: true },
-      { name: 'Combat', value: formatDfBonus(fruit.combatBonus), inline: true },
     );
 
   if (fruit.imageUrl) {
@@ -27,8 +24,4 @@ export function buildDevilFruitInfoEmbed(fruit: DevilFruitTemplate): EmbedBuilde
   }
 
   return embed;
-}
-
-function formatDfBonus(value: number): string {
-  return value >= 0 ? `+${value}` : String(value);
 }

--- a/packages/db/src/domains/character/character_template/schema.ts
+++ b/packages/db/src/domains/character/character_template/schema.ts
@@ -27,3 +27,4 @@ export const characterTemplate = pgTable(
 
 export type CharacterTemplateInsert = typeof characterTemplate.$inferInsert;
 export type CharacterTemplate = typeof characterTemplate.$inferSelect;
+export type CharacterCombatStats = Pick<CharacterTemplate, 'combat' | 'hp'>;

--- a/packages/db/src/domains/character/index.ts
+++ b/packages/db/src/domains/character/index.ts
@@ -1,3 +1,3 @@
 export { characterInstance, type CharacterInstance } from './character_instance/schema.js';
-export { characterTemplate, type CharacterTemplate } from './character_template/schema.js';
+export { characterTemplate, type CharacterCombatStats, type CharacterTemplate } from './character_template/schema.js';
 export { PLAYER_AS_CHARACTER_TEMPLATE_NAME } from './character_template/constants.js';

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -17,7 +17,12 @@ export {
 } from './domains/navigation/index.js';
 export { type Player } from './domains/player/index.js';
 export { type DevilFruitTemplate } from './domains/devil_fruit/index.js';
-export { PLAYER_AS_CHARACTER_TEMPLATE_NAME, type CharacterInstance, type CharacterTemplate } from './domains/character/index.js';
+export {
+  PLAYER_AS_CHARACTER_TEMPLATE_NAME,
+  type CharacterCombatStats,
+  type CharacterInstance,
+  type CharacterTemplate,
+} from './domains/character/index.js';
 export { SHIP_MODULE_KEYS, SHIP_MODULE_LEVEL_COLUMNS, type Ship, type ShipModuleKey } from './domains/ship/index.js';
 export { type ResourceName, type ResourceTemplate } from './domains/resource/index.js';
 export { type EventInstance } from './domains/event/index.js';


### PR DESCRIPTION
## Résumé

Centralise le calcul des stats effectives d’un personnage.

## Changements

- Ajout de `getEffectiveStats(character)`
- Prise en compte des bonus de fruit du démon dans `combat` et `hp`
- Extension de `CharacterRow` / `CharacterTemplateInfo` avec les infos de fruit nécessaires
- L’embed personnage affiche maintenant les stats finales
- L’embed fruit du démon n’affiche plus les bonus HP/Combat séparément