### PR TITLE
feat(player): setOnboardingStep helper

### DIFF
--- a/apps/bot/src/domains/player/repository.ts
+++ b/apps/bot/src/domains/player/repository.ts
@@ -1,4 +1,4 @@
-import { db, player, type DbOrTransaction, type Player, type SubZone, type Zone } from '@one-piece/db';
+import { db, player, type DbOrTransaction, type OnboardingStepId, type Player, type SubZone, type Zone } from '@one-piece/db';
 import { eq } from 'drizzle-orm';
 
 import { NotFoundError } from '../../discord/errors.js';
@@ -70,4 +70,12 @@ export async function updateCrewName(playerId: number, crewName: string, client:
 
 export async function setLastProcessedBucketId(playerId: number, bucketId: number, client: DbOrTransaction = db): Promise<void> {
   await client.update(player).set({ lastProcessedBucketId: bucketId }).where(eq(player.id, playerId));
+}
+
+export async function setOnboardingStep(
+  playerId: number,
+  step: OnboardingStepId | null,
+  client: DbOrTransaction = db,
+): Promise<void> {
+  await client.update(player).set({ onboardingStep: step }).where(eq(player.id, playerId));
 }


### PR DESCRIPTION
## Pourquoi

Préparation de l'onboarding scripté : on aura besoin d'un helper pour faire avancer le joueur d'étape en étape et marquer la fin (`null`).

## Ce qui change

Ajoute `setOnboardingStep(playerId, step, client)` dans `apps/bot/src/domains/player/repository.ts`. Aligné sur le pattern des autres updaters du repo (`setLastProcessedBucketId`, `updateName`...).

`step` accepte `OnboardingStepId | null` — `null` = onboarding terminé (la colonne DB est nullable, le default SQL gère l'init côté `create`).