### PR TITLE
feat(effects): addResource + addCharacter

### DIFF
--- a/apps/bot/src/domains/character/repository.ts
+++ b/apps/bot/src/domains/character/repository.ts
@@ -46,9 +46,18 @@ export async function getCharactersByPlayerId(playerId: number, client: DbOrTran
     .orderBy(desc(characterInstance.isCaptain), sql`${characterInstance.joinedCrewAt} asc nulls last`, asc(characterTemplate.name));
 }
 
+export async function findTemplateByName(name: string, client: DbOrTransaction = db): Promise<CharacterTemplate | undefined> {
+  const [row] = await client.select().from(characterTemplate).where(eq(characterTemplate.name, name)).limit(1);
+  return row;
+}
+
 // TODO: multi-statement → service avec tx
-export async function createCharacterInstance(playerId: number, templateId: number): Promise<CharacterRow> {
-  const [created] = await db
+export async function createCharacterInstance(
+  playerId: number,
+  templateId: number,
+  client: DbOrTransaction = db,
+): Promise<CharacterRow> {
+  const [created] = await client
     .insert(characterInstance)
     .values({
       playerId,
@@ -57,7 +66,7 @@ export async function createCharacterInstance(playerId: number, templateId: numb
     .returning();
   if (!created) throw new InternalError('Impossible de créer ce personnage.');
 
-  const [createdRow] = await db
+  const [createdRow] = await client
     .select({
       instanceId: characterInstance.id,
       name: characterTemplate.name,

--- a/apps/bot/src/domains/event/effects/apply-effects.ts
+++ b/apps/bot/src/domains/event/effects/apply-effects.ts
@@ -1,11 +1,14 @@
 import { type Transaction } from '@one-piece/db';
 
+import { NotFoundError } from '../../../discord/errors.js';
+import * as characterRepository from '../../character/repository.js';
 import * as economyRepository from '../../economy/repository.js';
 import { changeSubZone } from '../../navigation/services/change-sub-zone.js';
 import { completeTravel } from '../../navigation/services/complete-travel.js';
 import { startTravel } from '../../navigation/services/start-travel.js';
 import { updateTravelTarget } from '../../navigation/services/update-travel-target.js';
 import { getEntrySubZone } from '../../navigation/utils/index.js';
+import * as resourceRepository from '../../resource/repository.js';
 import type { GeneratorContext } from '../types.js';
 
 import type { EventEffect } from './types.js';
@@ -74,6 +77,19 @@ export async function applyEffects(effects: Array<EventEffect>, ctx: GeneratorCo
         ctx.player.currentSubZone = effect.targetSubZone;
         ctx.subZone = effect.targetSubZone;
         break;
+      case 'addResource': {
+        await resourceRepository.addResource({ playerId: ctx.player.id, name: effect.name, quantity: effect.quantity, options: { client: tx } });
+        const existing = ctx.inventory.find((r) => r.name === effect.name);
+        if (existing) existing.quantity += effect.quantity;
+        else ctx.inventory.push({ name: effect.name, quantity: effect.quantity });
+        break;
+      }
+      case 'addCharacter': {
+        const template = await characterRepository.findTemplateByName(effect.templateName, tx);
+        if (!template) throw new NotFoundError(`Personnage introuvable : ${effect.templateName}.`);
+        await characterRepository.createCharacterInstance(ctx.player.id, template.id, tx);
+        break;
+      }
     }
   }
 }

--- a/apps/bot/src/domains/event/effects/types.ts
+++ b/apps/bot/src/domains/event/effects/types.ts
@@ -1,4 +1,4 @@
-import type { Edge, Sea, SubZone } from '@one-piece/db';
+import type { Edge, ResourceName, Sea, SubZone } from '@one-piece/db';
 
 import type { TravelOutcome } from '../../navigation/types.js';
 
@@ -8,4 +8,6 @@ export type EventEffect =
   | { type: 'startTravel'; edge: Edge; etaBucket: number }
   | ({ type: 'completeTravel'; fromSea: Sea; startedBucket: number } & TravelOutcome)
   | { type: 'updateTravelTarget'; newEdge: Edge; newEtaBucket: number }
-  | { type: 'changeSubZone'; targetSubZone: SubZone };
+  | { type: 'changeSubZone'; targetSubZone: SubZone }
+  | { type: 'addResource'; name: ResourceName; quantity: number }
+  | { type: 'addCharacter'; templateName: string };

--- a/apps/bot/src/domains/fishing/service.ts
+++ b/apps/bot/src/domains/fishing/service.ts
@@ -12,7 +12,7 @@ export async function runFishingAttempt(playerId: number): Promise<FishingResult
   const picked = sample(templates);
   if (!picked) throw new Error('Aucun resource_template en base — exécute le seed avant de pêcher.');
 
-  await resourceRepository.addResourceToPlayer(playerId, picked.id, 1);
+  await resourceRepository.addResource({ playerId, name: picked.name, quantity: 1 });
   // TODO: SUPPRIMER EN PROD — log de test pour valider history
   await historyRepository.appendHistory({
     type: 'fishing.attempt',

--- a/apps/bot/src/domains/resource/repository.ts
+++ b/apps/bot/src/domains/resource/repository.ts
@@ -2,6 +2,7 @@ import { db, resourceInstance, resourceTemplate, type ResourceName, type Resourc
 import { and, asc, eq, getTableColumns, gte, ilike, or, sql } from 'drizzle-orm';
 
 import { NotFoundError } from '../../discord/errors.js';
+import type { ClientOptions } from '../../shared/types.js';
 
 import type { Inventory } from './types.js';
 
@@ -21,11 +22,21 @@ export async function listAllTemplates(): Promise<Array<ResourceTemplate>> {
   return db.select().from(resourceTemplate);
 }
 
-/** Ajoute n quantité d'une ressource à un joueur, si il avait déjà x ressource, alors la quantité devient x + y */
-export async function addResourceToPlayer(playerId: number, templateId: number, quantity: number): Promise<void> {
-  await db
+type AddResourceParams = {
+  playerId: number;
+  name: ResourceName;
+  quantity: number;
+  options?: ClientOptions;
+};
+
+/** Ajoute n quantité d'une ressource à un joueur. Si il en avait déjà x, la quantité devient x + y. */
+export async function addResource({ playerId, name, quantity, options = {} }: AddResourceParams): Promise<void> {
+  const { client = db } = options;
+  const [template] = await client.select({ id: resourceTemplate.id }).from(resourceTemplate).where(eq(resourceTemplate.name, name)).limit(1);
+  if (!template) throw new NotFoundError(`Ressource introuvable : ${name}.`);
+  await client
     .insert(resourceInstance)
-    .values({ playerId, templateId, quantity })
+    .values({ playerId, templateId: template.id, quantity })
     .onConflictDoUpdate({
       target: [resourceInstance.playerId, resourceInstance.templateId],
       set: { quantity: sql`${resourceInstance.quantity} + ${quantity}` },


### PR DESCRIPTION
## Pourquoi

Extension du framework d'effects pour permettre l'octroi de ressources et de personnages depuis un événement. Cas d'usage immédiat : l'onboarding scripté à venir. Cas d'usage moyen terme : générateurs du moteur de monde (rewards d'événements interactifs).

## Ce qui change

### Nouveaux `EventEffect`
- `{ type: 'addResource'; name: ResourceName; quantity: number }`
- `{ type: 'addCharacter'; templateName: string }`

Pattern aligné sur l'existant (`addBerries`/`spendBerries`).

### `apply-effects.ts`
- `addResource` : insert/increment via `resourceRepository.addResource` puis merge dans `ctx.inventory`.
- `addCharacter` : résout le template par nom (`findTemplateByName`), crée l'instance via `createCharacterInstance`. Le personnage va en **réserve** (`joinedCrewAt=null`), pas dans l'équipage actif — donc pas de mutation de `ctx.crew` (`isInCrewFilter` le rejette de toute façon).

### Repos
- `resourceRepository` : `addResourceToPlayer` (id-based) **supprimé** au profit d'une signature unique `addResource({ playerId, name, quantity, options? })". Param object (3 args métier, cf CLAUDE.md).
- `characterRepository` : ajout de `findTemplateByName(name, client?)` (exact match, distinct du fuzzy `searchManyByName`). `createCharacterInstance` accepte désormais un `client` pour propager la transaction.

### Callers existants
- `fishing/service.ts` migre vers `addResource({ playerId, name: picked.name, quantity: 1 })`.