### PR TITLE
fix(event): koby-encounter importe un helper supprimé, casse le boot du bot

### DIFF
--- a/apps/bot/src/domains/event/generators/interactive/koby-encounter.ts
+++ b/apps/bot/src/domains/event/generators/interactive/koby-encounter.ts
@@ -1,5 +1,4 @@
 import { buildDialogueEmbed, buildOpEmbed, type DialogueSpeaker } from '../../../../discord/utils/index.js';
-import { getCharacterInstanceName } from '../../../character/utils/get-character-instance-name.js';
 import type { GeneratorContext, InteractiveGenerator, Resolution } from '../../types.js';
 
 export const kobyEncounter: InteractiveGenerator = {
@@ -49,7 +48,7 @@ const KOBY_YOUNG: DialogueSpeaker = { name: 'Koby', path: 'characters/marines/ko
 
 function getCaptainSpeaker(ctx: GeneratorContext): DialogueSpeaker {
   const captain = ctx.crew.members.find((member) => member.isCaptain)!;
-  return { name: getCharacterInstanceName(captain), path: captain.imageUrl ?? '' };
+  return { name: captain.name, path: captain.imageUrl ?? '' };
 }
 
 function resolveEncounter(): Resolution {


### PR DESCRIPTION
## Contexte

Le \`main\` est cassé au démarrage du bot :

\`\`\`
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../apps/bot/src/domains/character/utils/get-character-instance-name.js' imported from .../apps/bot/src/domains/event/generators/interactive/koby-encounter.ts
\`\`\`

## Cause

Collision entre deux PR mergées indépendamment :
- #384 (commit \`aeb1c00\`) a **supprimé** le helper \`getCharacterInstanceName\` (le \`nickname\` n'existe plus ; le nom du perso vit désormais sur \`template.name\`, exposé via \`CharacterRow.name\`).
- #385 (commit \`ad3f840\`, koby-encounter) **importe toujours** ce helper supprimé → module introuvable au boot.

## Fix

Dans \`apps/bot/src/domains/event/generators/interactive/koby-encounter.ts\` :
- suppression de la ligne d'import morte ;
- \`getCharacterInstanceName(captain)\` remplacé par \`captain.name\` (pattern utilisé partout ailleurs après le refactor de #384).

## Typecheck

\`pnpm typecheck\` passe au vert (packages/db + apps/bot).