### PR TITLE
refactor(player): renomme getTargetUser en resolveTargetUser et migre givecharacter

### DIFF
--- a/apps/bot/src/discord/utils/get-target-user.ts
+++ b/apps/bot/src/discord/utils/get-target-user.ts
@@ -1,6 +1,0 @@
-import type { Message, User } from 'discord.js';
-
-/** Si quelqu'un est mentionné, on le prend ; sinon on prend l'auteur du message. */
-export function getTargetUser(message: Message): User {
-  return message.mentions.users.first() ?? message.author;
-}

--- a/apps/bot/src/discord/utils/index.ts
+++ b/apps/bot/src/discord/utils/index.ts
@@ -10,7 +10,7 @@ export { buildMenuButtons } from './build-menu-buttons.js';
 export { buildOpEmbed } from './build-op-embed.js';
 export { buildPaginationButtons } from './build-pagination-buttons.js';
 export { getQuery } from './get-query.js';
-export { getTargetUser } from './get-target-user.js';
+export { resolveTargetUser } from './resolve-target-user.js';
 export { clampPage, splitIntoPages } from './paginate.js';
 export { parseBigintArg } from './parse-bigint-arg.js';
 export { parseIntegerArg } from './parse-integer-arg.js';

--- a/apps/bot/src/discord/utils/resolve-target-user.ts
+++ b/apps/bot/src/discord/utils/resolve-target-user.ts
@@ -1,0 +1,6 @@
+import type { Message, User } from 'discord.js';
+
+/** User Discord ciblé (mentionné sinon auteur). Pour un Player (DB), utilise resolveTargetPlayer. */
+export function resolveTargetUser(message: Message): User {
+  return message.mentions.users.first() ?? message.author;
+}

--- a/apps/bot/src/domains/_dev/commands/dm.ts
+++ b/apps/bot/src/domains/_dev/commands/dm.ts
@@ -1,13 +1,13 @@
 import type { Command } from '../../../discord/types.js';
 import { getQuery } from '../../../discord/utils/get-query.js';
-import { getTargetUser } from '../../../discord/utils/get-target-user.js';
 import { buildOpEmbed } from '../../../discord/utils/index.js';
+import { resolveTargetUser } from '../../../discord/utils/resolve-target-user.js';
 import { sendDirectMessage } from '../../../discord/utils/send-direct-message.js';
 
 export const dmCommand: Command = {
   name: 'dm',
   async handler({ message, args }) {
-    const target = getTargetUser(message);
+    const target = resolveTargetUser(message);
     const queryArgs = message.mentions.users.first() ? args.slice(1) : args;
     const query = getQuery(queryArgs, { emptyMessage: 'Tu dois fournir un message.', minLength: 3 });
 

--- a/apps/bot/src/domains/_dev/commands/givecharacter.ts
+++ b/apps/bot/src/domains/_dev/commands/givecharacter.ts
@@ -1,25 +1,21 @@
 import { NotFoundError } from '../../../discord/errors.js';
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed, getQuery, getTargetUser } from '../../../discord/utils/index.js';
+import { buildOpEmbed, getQuery } from '../../../discord/utils/index.js';
 import * as characterRepository from '../../character/repository.js';
-import { findOrCreatePlayer } from '../../player/service.js';
+import { resolveTargetPlayer } from '../../player/index.js';
 
 // TODO: supprimer avant la prod
 export const giveCharacterCommand: Command = {
   name: ['givecharacter', 'gc'],
-  async handler({ message, args }) {
-    const target = getTargetUser(message);
-    const queryArgs = message.mentions.users.first() ? args.slice(1) : args;
-    const query = getQuery(queryArgs, { emptyMessage: 'Tu dois fournir un nom.' });
+  async handler(ctx) {
+    const { targetPlayer, rest } = await resolveTargetPlayer(ctx);
+    const query = getQuery(rest, { emptyMessage: 'Tu dois fournir un nom.' });
 
     const [hit] = await characterRepository.searchManyByName(query);
-    if (!hit) {
-      throw new NotFoundError(`Aucun personnage trouvé pour ${query}.`);
-    }
+    if (!hit) throw new NotFoundError(`Aucun personnage trouvé pour ${query}.`);
 
-    const { player: targetPlayer } = await findOrCreatePlayer(target.id, target.username, message.guildId!);
     const createdInstance = await characterRepository.createCharacterInstance(targetPlayer.id, hit.entity.id);
 
-    await message.reply({ embeds: [buildOpEmbed().setDescription(`${targetPlayer.name} a reçu ${createdInstance.name}.`)] });
+    await ctx.message.reply({ embeds: [buildOpEmbed().setDescription(`${targetPlayer.name} a reçu ${createdInstance.name}.`)] });
   },
 };

--- a/apps/bot/src/domains/_dev/commands/moi.ts
+++ b/apps/bot/src/domains/_dev/commands/moi.ts
@@ -1,11 +1,11 @@
 import type { Command } from '../../../discord/types.js';
-import { buildOpEmbed, getTargetUser } from '../../../discord/utils/index.js';
+import { buildOpEmbed, resolveTargetUser } from '../../../discord/utils/index.js';
 
 // TODO: supprimer avant la prod
 export const moiCommand: Command = {
   name: 'moi',
   async handler({ message }) {
-    const user = getTargetUser(message);
+    const user = resolveTargetUser(message);
     const embed = buildOpEmbed()
       .setAuthor({
         name: user.username,


### PR DESCRIPTION
## Contexte

Depuis l'arrivée de `resolveTargetPlayer` (qui résout un `Player` DB depuis le message + gère le slice des args), `getTargetUser` faisait doublon pour les commandes qui voulaient en réalité un PLAYER. 
Le helper reste **utile** pour les cas qui ont besoin du `User` Discord lui-même (avatar, envoi de DM), donc on le garde, mais on le renomme

## Changements

- **Renommage** : `getTargetUser` → `resolveTargetUser` (même nomenclature que `resolveTargetPlayer`)
- **`givecharacter.ts`** : migré vers `resolveTargetPlayer(ctx)` 
- Aucune logique métier modifiée, refactor pur.