### PR TITLE
refactor(event): seedScope player par défaut

### DIFF
--- a/apps/bot/src/domains/event/engine/rng.ts
+++ b/apps/bot/src/domains/event/engine/rng.ts
@@ -66,7 +66,7 @@ export function createRng(seed: number): Rng {
   };
 }
 
-/** Crée le RNG d'un générateur pour un bucket donné, en suivant son `seedScope` (zone ou player). */
+/** Crée le RNG d'un générateur pour un bucket donné, en suivant son `seedScope`. Par défaut (champ absent), le scope est `player`. */
 export function createRngForGenerator(gen: EventGenerator, ctx: GeneratorContext): Rng {
   const seed =
     gen.seedScope === 'zone' ? seedFromBucketAndZone(ctx.bucketId, ctx.zone) : seedFromBucketAndPlayer(ctx.bucketId, ctx.player.id);

--- a/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
+++ b/apps/bot/src/domains/event/generators/interactive/barrel-found.ts
@@ -6,7 +6,6 @@ import { getRandomIntBetween } from '../utils.js';
 export const barrelFound: InteractiveGenerator = {
   key: 'barrelFound',
   isInteractive: true,
-  seedScope: 'player',
   cooldownBuckets: inBuckets('3d'),
   probability: () => 0.1,
 

--- a/apps/bot/src/domains/event/generators/interactive/cheat-teleport.ts
+++ b/apps/bot/src/domains/event/generators/interactive/cheat-teleport.ts
@@ -8,7 +8,6 @@ import { noProbability } from '../utils.js';
 export const cheatTeleport: InteractiveGenerator = {
   key: 'cheatTeleport',
   isInteractive: true,
-  seedScope: 'player',
   probability: noProbability,
 
   initialStep: 'pickDestination',

--- a/apps/bot/src/domains/event/generators/interactive/koby-encounter.ts
+++ b/apps/bot/src/domains/event/generators/interactive/koby-encounter.ts
@@ -4,7 +4,6 @@ import type { GeneratorContext, InteractiveGenerator, Resolution } from '../../t
 export const kobyEncounter: InteractiveGenerator = {
   key: 'kobyEncounter',
   isInteractive: true,
-  seedScope: 'player',
   oneTime: true,
   probability: () => 0.05,
 

--- a/apps/bot/src/domains/event/generators/passive/arrivals/build-arrival-generator.ts
+++ b/apps/bot/src/domains/event/generators/passive/arrivals/build-arrival-generator.ts
@@ -16,7 +16,6 @@ export function buildArrivalGenerator(island: Island, content: ArrivalContent): 
   return {
     key: `${camelCase(island)}Arrival`,
     isInteractive: false,
-    seedScope: 'player',
     probability: noProbability,
     compute: noCompute,
     render: () =>

--- a/apps/bot/src/domains/event/generators/passive/drift-surprise.ts
+++ b/apps/bot/src/domains/event/generators/passive/drift-surprise.ts
@@ -14,7 +14,6 @@ const DRIFT_SURPRISE_MESSAGES = [
 export const driftSurprise: PassiveGenerator = {
   key: 'driftSurprise',
   isInteractive: false,
-  seedScope: 'player',
   probability: noProbability,
   compute: (_ctx, rng) => {
     const message = pickRandom(rng, DRIFT_SURPRISE_MESSAGES);

--- a/apps/bot/src/domains/event/generators/passive/peaceful-east-blue.ts
+++ b/apps/bot/src/domains/event/generators/passive/peaceful-east-blue.ts
@@ -6,7 +6,6 @@ import { noCompute } from '../utils.js';
 export const peacefulEastBlue: PassiveGenerator = {
   key: 'peacefulEastBlue',
   isInteractive: false,
-  seedScope: 'player',
   conditions: (ctx) => ctx.zone === 'sea_east_blue',
   oneTime: true,
   probability: () => 0.05,

--- a/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
+++ b/apps/bot/src/domains/event/generators/passive/seagull-flyby.ts
@@ -17,7 +17,6 @@ const IMAGES = ['events/passive/seagull-far.webp', 'events/passive/seagull-flyby
 export const seagullFlyby: PassiveGenerator = {
   key: 'seagullFlyby',
   isInteractive: false,
-  seedScope: 'player',
   conditions: (ctx) => isSea(ctx.zone),
   cooldownBuckets: inBuckets('1d'),
   probability: () => 0.3,

--- a/apps/bot/src/domains/event/types.ts
+++ b/apps/bot/src/domains/event/types.ts
@@ -33,7 +33,7 @@ export type GeneratorContext = {
 type GeneratorBase = {
   key: string;
   isInteractive: boolean;
-  seedScope: SeedScope;
+  seedScope?: SeedScope;
   conditions?: (ctx: GeneratorContext) => boolean;
   cooldownBuckets?: number;
   oneTime?: boolean;


### PR DESCRIPTION
## Contexte

Le `seedScope` des générateurs d'events était un champ **obligatoire** sur `GeneratorBase`, et la grande majorité des générateurs répétaient `seedScope: 'player'`. Cette ligne polluait chaque générateur sans rien apporter.

## Changements

- `seedScope` devient **optionnel** sur `GeneratorBase` (`seedScope?: SeedScope`). En l'absence du champ, le scope par défaut est `player`.
- Nettoyage des `seedScope: 'player'` redondants dans les générateurs concernés (interactive + passive + générateur d'arrivée).
- Ajustement du commentaire JSDoc de `createRngForGenerator` pour documenter le défaut `player`.

## Point d'attention

- `seedScope: 'zone'` reste **explicite** sur `rough-sea.ts` et `calm-sea.ts` (seul scope non-défaut).
- Comportement RNG **inchangé** : la branche `gen.seedScope === 'zone' ? … : …` retombe naturellement sur `player` quand le champ est absent.